### PR TITLE
Check all user roles when determining if user is a vendor

### DIFF
--- a/classes/class-vendors.php
+++ b/classes/class-vendors.php
@@ -286,8 +286,7 @@ class WCV_Vendors
 	{
 		$user = get_userdata( $user_id );
 
-		$role      = !empty( $user->roles ) ? array_shift( $user->roles ) : false;
-		$is_vendor = $role == 'vendor';
+		$is_vendor = in_array( 'vendor', $user->roles );
 
 		return apply_filters( 'pv_is_vendor', $is_vendor, $user_id );
 	}


### PR DESCRIPTION
Currently, `is_vendor` only checks the user's first role to see if it is assigned to "vendor". I personally like keeping WP's user roles intact, so I append the Vendor role to a user, similar to how bbPress creates roles in addition to WP's.

Doing this allows me to have someone be an Author and also a Vendor. I want to assign vendors without affecting their ability to author posts. This change simply makes sure that `is_vendor` checks the entire user role array for the value, instead of assuming that the role is assigned in the first value. This change should only add flexibility to the code, without breaking anything.