### PR TITLE
Remove Forced HTTP Protocol on Sent IPN URL

### DIFF
--- a/classes/gateways/PayPal_AdvPayments/paypal_ap.php
+++ b/classes/gateways/PayPal_AdvPayments/paypal_ap.php
@@ -373,7 +373,7 @@ class WC_PaypalAP extends WC_Payment_Gateway
 			'order_id'         	=> $order_id,
 		);
 
-		$payRequest->ipnNotificationUrl                = str_replace( 'https:', 'http:', add_query_arg( $args, home_url( '/' ) ) );
+		$payRequest->ipnNotificationUrl                = add_query_arg( $args, home_url( '/' ) );
 		$payRequest->memo                              = !empty( $order->customer_note ) ? $order->customer_note : '';
 		$payRequest->reverseAllParallelPaymentsOnError = true;
 


### PR DESCRIPTION
On line #376, the Instant Payment Notification URL sent to PayPal is forced to use HTTP even if the site uses an SSL certificate.

This presents a problem for websites that use SSL and Server Name Indication (SNI). All modern web browsers are sophisticated enough to handle SNI, however some remote calls made by applications (such as PayPal's IPN) are not able to find a route to the host because they are not able to be redirected appropriately. This is likely a security issue (unconfirmed).

Long story short, is it necessary to always force the URL to NOT use HTTPS? What is the benefit in this? For my site and anyone else using SNI this breaks IPN functionality.

This has been tested on my live site and has proven to fix IPN issues.

About SNI:
"SNI is a transport layer security extension which enables you to use a virtual domain name or a hostname to identify the network endpoint. From a single IP address and port number, you can use multiple SSL certificates to secure various websites on a single domain (i.e. www.yourdomain.com, site2.yourdomain.com) or across multiple domains (i.e. www.domain1.com, www.domain2.com)."