### PR TITLE
session fix

### DIFF
--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -79,7 +79,8 @@ if ( is_woocommerce_activated() ) {
 			add_action( self::$id . '_options_updated', array( $this, 'option_updates' ), 10, 2 );
 
 			// Start a PHP session, if not yet started
-			if ( !session_id() ) session_start();
+			/* this line will initialize session to early and for each page
+			if ( !session_id() ) session_start();*/
 		}
 
 

--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -144,9 +144,13 @@ class WCV_Vendor_Dashboard
 		$vendor_dashboard_page = WC_Vendors::$pv_options->get_option( 'vendor_dashboard_page' );
 		$shop_settings_page    = WC_Vendors::$pv_options->get_option( 'shop_settings_page' );
 
-		if ( ( is_page( $vendor_dashboard_page ) || is_page( $shop_settings_page ) ) && !is_user_logged_in() ) {
-			wp_redirect( get_permalink( woocommerce_get_page_id( 'myaccount' ) ) );
-			exit;
+		if ( is_page( $vendor_dashboard_page ) || is_page( $shop_settings_page ) ) {
+			if ( !is_user_logged_in() ) {
+				wp_redirect( get_permalink( woocommerce_get_page_id( 'myaccount' ) ) );
+				exit;
+			}
+			// user is logged, start session only if it's vendor dashboard
+			if ( !session_id() ) session_start();
 		}
 	}
 


### PR DESCRIPTION
I've tested it on my test server. And it works. Varnish + CDN services are affected. Default action for them is if any cookie exists page is non-cacheable. If you are stripping cookie PHPSESSID (in varnish configuration and forcing cache), php script can't use sessions (and some pages will be cached, but they shouldn't be in cache)

Before patch:

$ curl -I http://xxx.xxx/shop
.....
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Set-Cookie: PHPSESSID=........; path=/
.....

After patch:
$ curl -I http://xxx.xxx/shop
.....
Cache-Control: max-age=3600
Expires: Thu, 05 Nov 2015 00:04:29 GMT

No Set-Cookie in the header