### PR TITLE
Admin Orders Screen: Bugfixes

### DIFF
--- a/classes/admin/class-vendor-admin-dashboard.php
+++ b/classes/admin/class-vendor-admin-dashboard.php
@@ -437,7 +437,7 @@ class WCV_Vendor_Order_Page extends WP_List_Table
 				$products = ''; 
 
 				foreach ($valid as $key => $item) { 
-							$item_meta = new WC_Order_Item_Meta( $item[ 'item_meta' ] );
+							$item_meta = new WC_Order_Item_Meta( $item );
 							// $item_meta = $item_meta->display( false, true ); 
 							$item_meta = $item_meta->get_formatted( ); 
 							$products .= '<strong>'. $item['qty'] . ' x ' . $item['name'] . '</strong><br />'; 
@@ -450,8 +450,8 @@ class WCV_Vendor_Order_Page extends WP_List_Table
 				$shippers = (array) get_post_meta( $order->id, 'wc_pv_shipped', true );
 				$shipped = in_array($user_id, $shippers) ? 'Yes' : 'No' ; 
 
-				$sum = WCV_Queries::sum_for_orders( array( $order->id ), array('vendor_id' =>get_current_user_id() ) ); 
-				$total = $sum[0]->line_total; 
+				$sum = WCV_Queries::sum_for_orders( array( $order->id ), array('vendor_id' =>get_current_user_id(), 'dates' => array() ) ); 
+				$total = (!empty($sum)) ? $sum[0]->line_total : 0;
 
 				$comment_output = '';
 

--- a/classes/class-queries.php
+++ b/classes/class-queries.php
@@ -174,8 +174,21 @@ class WCV_Queries
 			FROM {$wpdb->prefix}pv_commission
 
 			WHERE   product_id IN ('" . implode( "','", $product_ids ) . "')
-			AND     time >= '" . $args[ 'dates' ][ 'after' ] . "'
-			AND     time <= '" . $args[ 'dates' ][ 'before' ] . "'
+		";
+		
+		if ( !empty( $args[ 'dates' ][ 'after' ] ) ) {
+			$sql .= "
+				AND     time >= '" . $args[ 'dates' ][ 'after' ] . "'
+			";
+		}
+		
+		if ( !empty( $args[ 'dates' ][ 'before' ] ) ) {
+			$sql .= "
+				AND     time <= '" . $args[ 'dates' ][ 'before' ] . "'
+			";
+		}
+		
+		$sql .= "
 			AND     status != 'reversed'
 		";
 


### PR DESCRIPTION
- Bugfix: wp-admin/orders screen now calculates vendor commission earned (per order) accurately in more cases. A date range was being applied to the SQL statement that calculated the total sum vendors earned per order. Orders on the admin screen may have been placed on dates that go outside of this date range so the SQL statement will gather no results in some those cases. The function that handles this can now be passed an empty "dates" parameter (it has always accepted dates, it can just now be empty), which will then withhold adding date restrictions to the list of results. Note: not having a date limit on this doesn't seem to be an issue because it's limited for one order. You _probably_ won't deal with an order that will return thousands of rows for one single order.
- Bugfix: error suppression - related to bug discussed above. If no results (commissions) are found for a single order, an error was being thrown while trying to access the first item in an empty array of results. It now makes sure that the array is not empty first.
- Update: WC_Order_Item_Meta was being used in a deprecated fashion. Newer versions of WooCommerce (2.4+) are passed $item instead of $item['item_meta']