### PR TITLE
Fixed HTML escaped characters in Cancel and Return URLs

### DIFF
--- a/classes/gateways/PayPal_AdvPayments/paypal_ap.php
+++ b/classes/gateways/PayPal_AdvPayments/paypal_ap.php
@@ -353,7 +353,7 @@ class WC_PaypalAP extends WC_Payment_Gateway
 		$receiverList = new ReceiverList( $receivers );
 
 		$actionType   = 'CREATE';
-		$cancelUrl    = str_replace('&amp;', '&', $order->get_cancel_order_url());
+		$cancelUrl    = $order->get_cancel_order_url_raw();
 		$currencyCode = get_woocommerce_currency();
 		$returnUrl    = esc_url_raw( add_query_arg( 'key', $order->order_key, add_query_arg( 'order-received', $order->id, $order->get_checkout_order_received_url() ) ) );
 


### PR DESCRIPTION
This is a follow up to commit e079ec2.

There is a regression since new WooCommerce update that breaks my fix. They have added a get_cancel_order_url_raw() methor for payment gateways that return clean unescaped URLs. Using this method now fixes the issue the clean way.