### PR TITLE
Don't start session if user isn't logged

### DIFF
--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -119,7 +119,7 @@ if ( wcv_is_woocommerce_activated() ) {
 		 */
 		public function init_session(){ 
 			
-			 if ( !session_id() ) {
+			 if ( !session_id() && is_user_logged_in() ) {
         		session_start();
     		 }
 


### PR DESCRIPTION
Now, init action opens sessions at each page, adding is_user_logged_in() in the condition will start session only if user is logged. It will help for varnish cache because PHPSESSID cookie blocks some CDN, varnish, etc...