### PR TITLE
added hook in links template

### DIFF
--- a/templates/dashboard/links.php
+++ b/templates/dashboard/links.php
@@ -6,7 +6,9 @@
 <?php if ( $can_submit ) { ?>
                 <a target="_TOP" href="<?php echo $submit_link; ?>" class="button"><?php echo _e( 'Add New Product', 'wcvendors' ); ?></a>
                 <a target="_TOP" href="<?php echo $edit_link; ?>" class="button"><?php echo _e( 'Edit Products', 'wcvendors' ); ?></a>
-<?php } ?>
+<?php } 
+do_action( 'wcvendors_after_links' );
+?>
 </center>
 
 <hr>


### PR DESCRIPTION
I need to add a link to the Free Dashboard... afaik, the only hook there is
do_action( 'wcvendors_before_dashboard' );

Which places a new link above the other links.

Solution: Adding a new hook 