### PR TITLE
Added Phone Number Support

### DIFF
--- a/classes/admin/settings/sf-options.php
+++ b/classes/admin/settings/sf-options.php
@@ -226,6 +226,14 @@ $options[ ] = array(
 );
 
 $options[ ] = array(
+	'desc' => __( 'View phone numbers', 'wcvendors' ),
+	'tip'  => __( 'While viewing order details on the frontend, you can disable or enable phone numbers', 'wcvendors' ),
+	'id'   => 'can_view_order_phone',
+	'type' => 'checkbox',
+	'std'  => false,
+);
+
+$options[ ] = array(
 	'desc' => __( 'Export a CSV file of orders for a product', 'wcvendors' ),
 	'tip'  => __( 'Vendors could export orders for a product on the frontend', 'wcvendors' ),
 	'id'   => 'can_export_csv',


### PR DESCRIPTION
Option for customer phone numbers to be shown on vendors' order details page added. This goes along with the changes to the classes/front/orders/class-orders.php file. Original thread: https://www.wcvendors.com/help/topic/how-can-i-let-vendors-see-customer-phone-number-in-order-details/