### PR TITLE
Always pass current section to wcvendors_get_settings_{$this->id}

### DIFF
--- a/classes/admin/settings/class-wcv-settings-commission.php
+++ b/classes/admin/settings/class-wcv-settings-commission.php
@@ -53,27 +53,31 @@ class WCVendors_Settings_Commission extends WCVendors_Settings_Page {
 	 */
 	public function get_settings( $current_section = '' ) {
 
-		$settings = apply_filters( 'wcvendors_settings_comission', array(
+		$settings = array();
 
-			//  General Options
-			array(
-				'type'     => 'title',
-				'desc'     => __( 'These are the commission settings for your marketplace', 'wc-vendors' ),
-				'id'       => 'commission_options',
-			),
-			array(
-				'title'    => sprintf( __( '%s Commission %%', 'wc-vendors' ), wcv_get_vendor_name() ),
-				'desc'     => sprintf( __( 'The global commission rate for your %s', 'wc-vendors' ), lcfirst( wcv_get_vendor_name( false ) ) ),
-				'id'       => 'wcvendors_vendor_commission_rate',
-				'css'      => 'width:50px;',
-				'default'  => '50',
-				'type'     => 'number',
-			),
-			array( 'type' => 'sectionend', 'id' => 'commission_options' ),
+		if ( '' === $current_section ) {
+			$settings = apply_filters( 'wcvendors_settings_comission', array(
 
-		) );
+				//  General Options
+				array(
+					'type'     => 'title',
+					'desc'     => __( 'These are the commission settings for your marketplace', 'wc-vendors' ),
+					'id'       => 'commission_options',
+				),
+				array(
+					'title'    => sprintf( __( '%s Commission %%', 'wc-vendors' ), wcv_get_vendor_name() ),
+					'desc'     => sprintf( __( 'The global commission rate for your %s', 'wc-vendors' ), lcfirst( wcv_get_vendor_name( false ) ) ),
+					'id'       => 'wcvendors_vendor_commission_rate',
+					'css'      => 'width:50px;',
+					'default'  => '50',
+					'type'     => 'number',
+				),
+				array( 'type' => 'sectionend', 'id' => 'commission_options' ),
 
-		return apply_filters( 'wcvendors_get_settings_' . $this->id, $settings );
+			) );
+		}
+
+		return apply_filters( 'wcvendors_get_settings_' . $this->id, $settings, $current_section );
 	}
 
 }

--- a/classes/admin/settings/class-wcv-settings-general.php
+++ b/classes/admin/settings/class-wcv-settings-general.php
@@ -53,49 +53,53 @@ class WCVendors_Settings_General extends WCVendors_Settings_Page {
 	 */
 	public function get_settings( $current_section = '' ) {
 
-		$settings = apply_filters( 'wcvendors_settings', array(
+		$settings = array();
 
-			//  General Options
-			array(
-				'title'    => __( 'Marketplace Options', 'wc-vendors' ),
-				'type'     => 'title',
-				'desc'     => __( 'These are the general settings for your marketplace', 'wc-vendors' ),
-				'id'       => 'general_options',
-			),
-			array(
-				'title'   => sprintf( __( '%s Registration', 'wc-vendors' ), wcv_get_vendor_name() ),
-				'desc'    => sprintf( __( 'Allow users to apply to become a %s', 'wc-vendors' ), lcfirst( wcv_get_vendor_name() ) ),
-				'id'      => 'wcvendors_vendor_allow_registration',
-				'default' => 'yes',
-				'type'    => 'checkbox',
-			),
-			array(
-				'title'   => sprintf( __( '%s Approval', 'wc-vendors' ), wcv_get_vendor_name() ),
-				'desc'    => sprintf( __( 'Manually approve all %s applications', 'wc-vendors' ), lcfirst( wcv_get_vendor_name() ) ),
-				'id'      => 'wcvendors_vendor_approve_registration',
-				'default' => 'no',
-				'type'    => 'checkbox',
-			),
+		if ( '' === $current_section ) {
+			$settings = apply_filters( 'wcvendors_settings', array(
 
-			array(
-				'title'   => sprintf( __( '%s Taxes', 'wc-vendors' ), wcv_get_vendor_name() ),
-				'desc'    => sprintf( __( 'Give any taxes to the %s', 'wc-vendors' ), wcv_get_vendor_name() ),
-				'id'      => 'wcvendors_vendor_give_taxes',
-				'default' => 'no',
-				'type'    => 'checkbox',
-			),
-			array(
-				'title'   => sprintf( __( '%s Shipping', 'wc-vendors' ), wcv_get_vendor_name() ),
-				'desc'    => sprintf( __( 'Give any shipping to the %s', 'wc-vendors' ), wcv_get_vendor_name() ),
-				'id'      => 'wcvendors_vendor_give_shipping',
-				'default' => 'no',
-				'type'    => 'checkbox',
-			),
-			array( 'type' => 'sectionend', 'id' => 'general_options' ),
+				//  General Options
+				array(
+					'title'    => __( 'Marketplace Options', 'wc-vendors' ),
+					'type'     => 'title',
+					'desc'     => __( 'These are the general settings for your marketplace', 'wc-vendors' ),
+					'id'       => 'general_options',
+				),
+				array(
+					'title'   => sprintf( __( '%s Registration', 'wc-vendors' ), wcv_get_vendor_name() ),
+					'desc'    => sprintf( __( 'Allow users to apply to become a %s', 'wc-vendors' ), lcfirst( wcv_get_vendor_name() ) ),
+					'id'      => 'wcvendors_vendor_allow_registration',
+					'default' => 'yes',
+					'type'    => 'checkbox',
+				),
+				array(
+					'title'   => sprintf( __( '%s Approval', 'wc-vendors' ), wcv_get_vendor_name() ),
+					'desc'    => sprintf( __( 'Manually approve all %s applications', 'wc-vendors' ), lcfirst( wcv_get_vendor_name() ) ),
+					'id'      => 'wcvendors_vendor_approve_registration',
+					'default' => 'no',
+					'type'    => 'checkbox',
+				),
 
-		) );
+				array(
+					'title'   => sprintf( __( '%s Taxes', 'wc-vendors' ), wcv_get_vendor_name() ),
+					'desc'    => sprintf( __( 'Give any taxes to the %s', 'wc-vendors' ), wcv_get_vendor_name() ),
+					'id'      => 'wcvendors_vendor_give_taxes',
+					'default' => 'no',
+					'type'    => 'checkbox',
+				),
+				array(
+					'title'   => sprintf( __( '%s Shipping', 'wc-vendors' ), wcv_get_vendor_name() ),
+					'desc'    => sprintf( __( 'Give any shipping to the %s', 'wc-vendors' ), wcv_get_vendor_name() ),
+					'id'      => 'wcvendors_vendor_give_shipping',
+					'default' => 'no',
+					'type'    => 'checkbox',
+				),
+				array( 'type' => 'sectionend', 'id' => 'general_options' ),
 
-		return apply_filters( 'wcvendors_get_settings_' . $this->id, $settings );
+			) );
+		}
+
+		return apply_filters( 'wcvendors_get_settings_' . $this->id, $settings, $current_section );
 	}
 
 }


### PR DESCRIPTION
This change enables developers to add new sections to the General and Commission settings tabs if need be.