### PR TITLE
Revert "Fix fatal error get id on non object"

### DIFF
--- a/classes/admin/class-vendor-admin-dashboard.php
+++ b/classes/admin/class-vendor-admin-dashboard.php
@@ -501,9 +501,8 @@ class WCV_Vendor_Order_Page extends WP_List_Table
 		if ( !empty( $_orders ) ) {
 
 			foreach ( $_orders as $order ) {
-				if ( ! is_a( $order, 'WC_Order' ) ) {
-					$order 			= wc_get_order( $order );
-				}				
+
+				$order 			= wc_get_order( $order->order_id );
 				$order_id 		= $order->get_id();
 				$valid_items 	= WCV_Queries::get_products_for_order( $order_id );
 				$valid 			= array();

--- a/classes/admin/emails/class-emails.php
+++ b/classes/admin/emails/class-emails.php
@@ -153,9 +153,7 @@ class WCV_Emails
 	*
 	*/
 	public function order_actions_save( $order ){
-		if ( ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order );
-		}
+
 		WC()->mailer()->emails[ 'WC_Email_Notify_Vendor' ]->trigger( $order->get_id(), $order );
 		WC()->mailer()->emails[ 'WCVendors_Vendor_Notify_Order' ]->trigger( $order->get_id(), $order );
 	}
@@ -166,9 +164,6 @@ class WCV_Emails
 	* @since 2.0.0
 	*/
 	public function vendor_shipped( $order_id, $user_id, $order ){
-		if ( ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order_id );
-		}
 		// Notify the admin
 		WC()->mailer()->emails[ 'WCVendors_Admin_Notify_Shipped' ]->trigger( $order->get_id(), $user_id, $order );
 		// Notify the customer


### PR DESCRIPTION
Reverts wcvendors/wcvendors#426 doesn't fix the error on the wp-admin/admin.php?page=wcv-vendor-orders page. 