### PR TITLE
Fixed: Commission by Product report is not functioning

### DIFF
--- a/classes/admin/class-admin-reports.php
+++ b/classes/admin/class-admin-reports.php
@@ -238,7 +238,9 @@ class WCV_Admin_Reports
 			</select>
 			<?php if ( $_GET[ 'report' ] == 2 ) {
 					if ($latest_woo) { ?>
-						<input type="hidden" class="wc-product-search" style="width:203px;" name="product_ids[]" data-placeholder="<?php _e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations" />
+						<select id="product_ids" name="product_ids[]" class="wc-product-search ajax_chosen_select_products" multiple="multiple"
+						data-placeholder="<?php _e( 'Type in a product name to start searching...', 'wc-vendors' ); ?>"
+						style="width: 400px;"></select>
 			<?php } else { ?>
 						<select id="product_ids" name="product_ids[]" class="ajax_chosen_select_products" multiple="multiple"
 						data-placeholder="<?php _e( 'Type in a product name to start searching...', 'wc-vendors' ); ?>"


### PR DESCRIPTION
Issue: https://github.com/wcvendors/wcvendors/issues/456

The textbox is using the Chosen library which was replaced by Select2 so it was not getting the list of products.