### PR TITLE
Handle PayPal Adaptive Payments IPN status inconsistencies

### DIFF
--- a/classes/gateways/PayPal_AdvPayments/paypal_ap.php
+++ b/classes/gateways/PayPal_AdvPayments/paypal_ap.php
@@ -115,7 +115,7 @@ class WC_PaypalAP extends WC_Payment_Gateway
 		$order = wc_get_order( $order_id );
 		if ( !$order ) return false;
 
-		if ( $_POST[ 'status' ] !== 'COMPLETED' ) {
+		if ( ! in_array( $_POST['status'], array( 'COMPLETED', 'Completed' ), true ) ) {
 			$order->update_status( 'failed', sprintf( __( 'Something went wrong. Response from PayPal invalidated this order. Status: %s.', 'wc-vendors' ), $_POST[ 'status' ] ) );
 			exit;
 		}


### PR DESCRIPTION
For the Adaptive Payments IPN, if the vendor commission is set to 100%, the status sent by PayPal is `Completed`. If the commission is less than 100%, and the money gets sent to 2 or more PayPal addresses the status is `COMPLETED`.

This causes the order to be marked as Failed in WooCommerce although the payment went through.

PayPal will most likely not change this as the Adaptive Payments are no longer supported.