### PR TITLE
Updated: Treat product as vendor page if product author is vendor

### DIFF
--- a/classes/class-vendors.php
+++ b/classes/class-vendors.php
@@ -438,9 +438,13 @@ class WCV_Vendors {
 		return ( 'Vendor' === $role ) ? true : false;
 	}
 
-	/*
-	*	Is this the vendors shop archive page ?
-	*/
+	/**
+	 * Is this the vendors shop archive page or a single vendor product?
+	 *
+	 * @return boolean
+	 * @since 2.1.3
+	 * @version 2.1.3
+	 */
 	public static function is_vendor_page() {
 		global $post;
 

--- a/classes/class-vendors.php
+++ b/classes/class-vendors.php
@@ -442,11 +442,16 @@ class WCV_Vendors {
 	*	Is this the vendors shop archive page ?
 	*/
 	public static function is_vendor_page() {
+		global $post;
 
 		$vendor_shop = urldecode( get_query_var( 'vendor_shop' ) );
 		$vendor_id   = WCV_Vendors::get_vendor_id( $vendor_shop );
 
-		return $vendor_id ? true : false;
+		if ( ! $vendor_id && is_a( $post, 'WC_Product' ) ) {
+			if ( self::is_vendor( $post->post_author ) ) {
+				$vendor_id = $post->post_author;
+			}
+		}
 
 	} // is_vendor_page()
 

--- a/classes/class-vendors.php
+++ b/classes/class-vendors.php
@@ -457,6 +457,8 @@ class WCV_Vendors {
 			}
 		}
 
+		return $vendor_id ? true : false;
+
 	} // is_vendor_page()
 
 	/*


### PR DESCRIPTION
Treat a single product page as a vendor page. This will allow the vendor widgets to be displayed on single product pages, for instance, the store contact widget should be displayed on single product pages to allow user to be able to contact the vendor from the product page.