### PR TITLE
Fixed: Shipping is saved in db as integer.

### DIFF
--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -366,7 +366,7 @@ class WCV_Commission
 			$count = WCV_Commission::check_commission_status( $order, 'paid' );
 
 			if ( 0 == $count ) {
-				$format = array( "%d", "%d", "%d", "%f", "%d", "%f", "%f", "%s", "%s" );
+				$format = array( "%d", "%d", "%d", "%f", "%f", "%f", "%f", "%s", "%s" );
 				$update = $wpdb->update( $table, $order, $where, $format  );
 				if ( !$update ) $insert = $wpdb->insert( $table, $order,  $format );
 			}


### PR DESCRIPTION
Fix introduced in wcvendors/wcvendors#499 breaks shipping value float support.

This aim to format shipping value as a float like it's done elsewhere. BTW, regarding initial comment on the issue, the initial proposal was to set as string, but I guess float is better since aligned with other values.