### PR TITLE
Fixed: Shortcode not showing in container when used in page builders

### DIFF
--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -739,16 +739,22 @@ class WCV_Shortcodes {
 
 		if ( ! is_product() ) return; 
 
-		$vendor_id         = get_the_author_meta( 'ID' );
-		$sold_by_label     = get_option( 'wcvendors_label_sold_by' );
-		$sold_by_separator = get_option( 'wcvendors_label_sold_by_separator' );
+		$atts = shortcode_atts(			
+			array(
+				'vendor_id'         => get_the_author_meta( 'ID' ),
+				'sold_by_label'     => get_option( 'wcvendors_label_sold_by' ),
+				'sold_by_separator' => get_option( 'wcvendors_label_sold_by_separator' ),
+			),
+			$atts,
+			'wcv_sold_by'
+		);
+		extract( $atts );
+
 		$sold_by           = WCV_Vendors::is_vendor( $vendor_id )
 			? sprintf( '<a href="%s" class="wcvendors_cart_sold_by_meta">%s</a>', WCV_Vendors::get_vendor_shop_page( $vendor_id ), WCV_Vendors::get_vendor_sold_by( $vendor_id ) )
 			: get_bloginfo( 'name' );
 
 		return apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
-
-
 	}
 
 }

--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -746,7 +746,7 @@ class WCV_Shortcodes {
 			? sprintf( '<a href="%s" class="wcvendors_cart_sold_by_meta">%s</a>', WCV_Vendors::get_vendor_shop_page( $vendor_id ), WCV_Vendors::get_vendor_sold_by( $vendor_id ) )
 			: get_bloginfo( 'name' );
 
-		echo apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
+		return apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
 
 
 	}


### PR DESCRIPTION
Used return instead of echoing the shortcode content, added support for overrides.
Issue:  #544