### PR TITLE
Fix wrong user meta name for bank account number

### DIFF
--- a/classes/admin/class-vendor-admin-dashboard.php
+++ b/classes/admin/class-vendor-admin-dashboard.php
@@ -129,7 +129,7 @@ class WCV_Vendor_Admin_Dashboard {
 				update_user_meta( $user_id, 'wcv_bank_account_name', $_POST['wcv_bank_account_name'] );
 			}
 			if ( isset( $_POST['wcv_bank_account_number'] ) ) {
-				update_user_meta( $user_id, 'wcv_bank_account_name', $_POST['wcv_bank_account_name'] );
+				update_user_meta( $user_id, 'wcv_bank_account_number', $_POST['wcv_bank_account_number'] );
 			}
 			if ( isset( $_POST['wcv_bank_name'] ) ) {
 				update_user_meta( $user_id, 'wcv_bank_name', $_POST['wcv_bank_name'] );


### PR DESCRIPTION
Original repoter: https://wordpress.org/support/topic/i-can-not-save-bank-account-number/#post-11636550

The user meta name of the saving method is wrong. That leads to vendor can't edit bank account number in the WordPress dashboard. This PR correct that name so the vendor can edit bank account number in the WP dashboard.