### PR TITLE
Fixed: Sold by filters have space in them #546

### DIFF
--- a/classes/front/class-vendor-cart.php
+++ b/classes/front/class-vendor-cart.php
@@ -64,7 +64,12 @@ class WCV_Vendor_Cart {
 			? sprintf( '<a href="%s" class="wcvendors_cart_sold_by_meta">%s</a>', WCV_Vendors::get_vendor_shop_page( $vendor_id ), WCV_Vendors::get_vendor_sold_by( $vendor_id ) )
 			: get_bloginfo( 'name' );
 
-		echo apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
+		printf(
+			apply_filters( 'wcvendors_cart_sold_by_meta_template', '%1$s %2$s %3$s<br/>', get_the_ID(), $vendor_id ),
+			apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ),
+			apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ),
+			$sold_by
+		);
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add new filter `wcvendors_cart_sold_by_meta_template` which is set to `%1$s %2$s %3$s<br/>` by default. Developer can hook into this filter to change how sold by meta is display.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #546.
