### PR TITLE
Fixed: Approving a vendor sends an email to the admin #578

### DIFF
--- a/classes/admin/emails/class-emails.php
+++ b/classes/admin/emails/class-emails.php
@@ -87,11 +87,13 @@ class WCV_Emails {
 	}
 
 	/**
+	 * Load WooCommerce email classes.
 	 *
+	 * @param   array $emails Current list of WooCommerce emails.
+	 * @version 2.0.13
+	 * @since   1.0.0
 	 *
-	 * @param unknown $emails
-	 *
-	 * @return unknown
+	 * @return array
 	 */
 	public function email_classes( $emails ) {
 
@@ -100,17 +102,18 @@ class WCV_Emails {
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wc-approve-vendor.php';
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wc-notify-shipped.php';
 
-		// Emails to depreciate
+		// Emails to depreciate.
 		$emails['WC_Email_Notify_Vendor']  = new WC_Email_Notify_Vendor();
 		$emails['WC_Email_Approve_Vendor'] = new WC_Email_Approve_Vendor();
 		$emails['WC_Email_Notify_Admin']   = new WC_Email_Notify_Admin();
 		$emails['WC_Email_Notify_Shipped'] = new WC_Email_Notify_Shipped();
 
-		// New emails introduced in @since 2.0.0
+		// New emails introduced in @since 2.0.0.
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wcv-customer-notify-shipped.php';
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wcv-admin-notify-shipped.php';
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wcv-admin-notify-product.php';
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wcv-admin-notify-application.php';
+		require_once wcv_plugin_dir . 'classes/admin/emails/class-wcv-admin-notify-approved.php';
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wcv-vendor-notify-application.php';
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wcv-vendor-notify-approved.php';
 		require_once wcv_plugin_dir . 'classes/admin/emails/class-wcv-vendor-notify-denied.php';
@@ -121,6 +124,7 @@ class WCV_Emails {
 		$emails['WCVendors_Admin_Notify_Shipped']          = new WCVendors_Admin_Notify_Shipped();
 		$emails['WCVendors_Admin_Notify_Product']          = new WCVendors_Admin_Notify_Product();
 		$emails['WCVendors_Admin_Notify_Application']      = new WCVendors_Admin_Notify_Application();
+		$emails['WCVendors_Admin_Notify_Approved']         = new WCVendors_Admin_Notify_Approved();
 		$emails['WCVendors_Vendor_Notify_Application']     = new WCVendors_Vendor_Notify_Application();
 		$emails['WCVendors_Vendor_Notify_Approved']        = new WCVendors_Vendor_Notify_Approved();
 		$emails['WCVendors_Vendor_Notify_Denied']          = new WCVendors_Vendor_Notify_Denied();
@@ -129,7 +133,7 @@ class WCV_Emails {
 
 		return $emails;
 
-	} // email_classes()
+	} // email_classes
 
 	/**
 	 *   Add the vendor email to the low stock emails.
@@ -250,7 +254,7 @@ class WCV_Emails {
 		} elseif ( $role == 'vendor' ) {
 			$status = __( 'approved', 'wc-vendors' );
 			WC()->mailer()->emails['WCVendors_Vendor_Notify_Approved']->trigger( $user_id, $status );
-			WC()->mailer()->emails['WCVendors_Admin_Notify_Application']->trigger( $user_id, $status );
+			WC()->mailer()->emails['WCVendors_Admin_Notify_Approved']->trigger( $user_id, $status );
 		}
 
 	}

--- a/classes/admin/emails/class-wcv-admin-notify-approved.php
+++ b/classes/admin/emails/class-wcv-admin-notify-approved.php
@@ -1,33 +1,38 @@
 <?php
-
+/**
+ * Defines the class to send admin notification for approved vendors.
+ *
+ * @version     2.0.13
+ * @package     Classes/Admin/Emails
+ * @author      WC Vendors
+ */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! class_exists( 'WCVendors_Admin_Notify_Application' ) ) :
+if ( ! class_exists( 'WCVendors_Admin_Notify_Approved' ) ) :
 
 	/**
-	 * Notify Admin Application
+	 * Notify Admin Approved
 	 *
-	 * An email sent to the admin when a user applies to be a vendor
+	 * An email sent to the admin when admin approves a user to be a vendor
 	 *
-	 * @class       WCVendors_Admin_Notify_Shipped
-	 * @version     2.0.0
-	 * @package     Classes/Admin/Emails
-	 * @author      WC Vendors
-	 * @extends     WC_Email
+	 * @since   2.0.
+	 * @version 2.0.
+	 * @class   WCVendors_Admin_Notify_Approved
+	 * @extends WC_Email
 	 */
-	class WCVendors_Admin_Notify_Application extends WC_Email {
+	class WCVendors_Admin_Notify_Approved extends WC_Email {
 
 		/**
 		 * Constructor.
 		 */
 		public function __construct() {
 			$this->id             = 'admin_notify_application';
-			$this->title          = sprintf( __( 'Admin notify %s application', 'wc-vendors' ), wcv_get_vendor_name( true, false ) );
-			$this->description    = sprintf( __( 'Notification is sent to chosen recipient(s) when a user applies to be a %s', 'wc-vendors' ), wcv_get_vendor_name( true, false ) );
-			$this->template_html  = 'emails/admin-notify-application.php';
-			$this->template_plain = 'emails/plain/admin-notify-application.php';
+			$this->title          = sprintf( __( 'Admin notify %s approved', 'wc-vendors' ), wcv_get_vendor_name( true, false ) );
+			$this->description    = sprintf( __( 'Notification is sent to chosen recipient(s) when admin approves a user to be a %s', 'wc-vendors' ), wcv_get_vendor_name( true, false ) );
+			$this->template_html  = 'emails/admin-notify-approved.php';
+			$this->template_plain = 'emails/plain/admin-notify-approved.php';
 			$this->template_base  = dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/templates/';
 			$this->placeholders   = array(
 				'{site_title}' => $this->get_blogname(),
@@ -48,7 +53,7 @@ if ( ! class_exists( 'WCVendors_Admin_Notify_Application' ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return sprintf( __( '[{site_title}] {user_name} has applied to be a %s', 'wc-vendors' ), wcv_get_vendor_name( true, false ) );
+			return sprintf( __( '[{site_title}] {user_name} has been approved to be a %s', 'wc-vendors' ), wcv_get_vendor_name( true, false ) );
 		}
 
 		/**
@@ -58,7 +63,7 @@ if ( ! class_exists( 'WCVendors_Admin_Notify_Application' ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return sprintf( __( '%s application received', 'wc-vendors' ), wcv_get_vendor_name() );
+			return sprintf( __( '%s application approved', 'wc-vendors' ), wcv_get_vendor_name() );
 		}
 
 		/**
@@ -76,7 +81,7 @@ if ( ! class_exists( 'WCVendors_Admin_Notify_Application' ) ) :
 			$this->placeholders['{user_name}'] = $this->user->user_login;
 
 			$send_if     = $this->get_option( 'notification' );
-			$should_send = $send_if == 'vendor' ? true : ( $send_if == 'pending_vendor' && $status == 'pending' ? true : false );
+			$should_send = $send_if == 'vendor' ? true : ( $send_if == 'vendor' && $status == 'approved' ? true : false );
 
 			if ( $this->is_enabled() && $this->get_recipient() && $should_send ) {
 				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
@@ -173,7 +178,7 @@ if ( ! class_exists( 'WCVendors_Admin_Notify_Application' ) ) :
 					'title'       => __( 'Notification', 'wc-vendors' ),
 					'type'        => 'select',
 					'description' => __( 'Choose when to be notified of an application.', 'wc-vendors' ),
-					'default'     => 'pending_vendor',
+					'default'     => 'vendor',
 					'class'       => 'wc-enhanced-select',
 					'options'     => array(
 						'vendor'         => __( 'All Applications', 'wc-vendors' ),

--- a/classes/admin/emails/class-wcv-vendor-notify-application.php
+++ b/classes/admin/emails/class-wcv-vendor-notify-application.php
@@ -63,7 +63,7 @@ if ( ! class_exists( 'WCVendors_Vendor_Notify_Application' ) ) :
 
 		public function get_default_content() {
 
-			return sprintf( __( 'Hi there. This is a notification about a %1$s application on %2$s.', 'wc-vendors' ), wcv_get_vendor_name( true, false ), get_option( 'blogname' ) );
+			return sprintf( __( 'Hi there. This is a notification about your %1$s application on %2$s.', 'wc-vendors' ), wcv_get_vendor_name( true, false ), get_option( 'blogname' ) );
 		}
 
 		/**

--- a/classes/admin/emails/class-wcv-vendor-notify-approved.php
+++ b/classes/admin/emails/class-wcv-vendor-notify-approved.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WCVendors_Vendor_Notify_Approved' ) ) :
 		 */
 		public function get_default_subject() {
 
-			return __( '[{site_title}] Your vendor application has been approved', 'wc-vendors' );
+			return sprintf( __( '[{site_title}] Your %s application has been approved', 'wc-vendors' ), wcv_get_vendor_name( true, false ) );
 		}
 
 		/**

--- a/templates/emails/admin-notify-approved.php
+++ b/templates/emails/admin-notify-approved.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Notify admin about an approved vendor
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/admin-notify-approved.php.
+ *
+ * @author        Lindeni Mahlalela, WC Vendors
+ * @package       WCVendors/Templates/Emails/HTML
+ * @version       2.1.7
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+
+	<p><?php printf( __( 'Hi there. You or another admin has approved a user to be a %1$s on %2$s.', 'wc-vendors' ), wcv_get_vendor_name( true, false ), get_option( 'blogname' ) ); ?></p>
+	<p><?php printf( __( 'Application status: %s', 'wc-vendors' ), esc_attr( ucfirst( $status ) ) ); ?></p>
+	<p><?php printf( __( 'Applicant username: %s', 'wc-vendors' ), esc_attr( $user->user_login ) ); ?></p>
+
+<?php
+
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/plain/admin-notify-approved.php
+++ b/templates/emails/plain/admin-notify-approved.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Admin new notify vendor approved (plain text)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/admin-notify-approved.php
+ *
+ * @author         Lindeni Mahlalela, WC Vendors
+ * @package        WCVendors/Templates/Emails/Plain
+ * @version        2.0.13
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+echo '= ' . $email_heading . " =\n\n";
+
+echo sprintf( __( 'Hi there. You or another admin has approved a user to be a %1$s on %2$s.', 'wc-vendors' ), wcv_get_vendor_name( true, false ), get_option( 'blogname' ) ) . "\n\n";
+echo sprintf( __( 'Application status: %s', 'wc-vendors' ), esc_attr(ucfirst( $status ) ) );
+echo sprintf( __( 'Approved username: %s', 'wc-vendors' ), esc_attr( $user->user_login ) ) . "\n\n";
+
+
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/emails/vendor-notify-application.php
+++ b/templates/emails/vendor-notify-application.php
@@ -7,6 +7,7 @@
  * @author  WC Vendors
  * @package WCVendors/Templates/Emails
  * @version 2.0.0
+ * @since   1.0.13
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -18,9 +19,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-	<p><?php printf( __( 'Hi there. This is a notification about a %1$s application on %2$s.', 'wc-vendors' ), wcv_get_vendor_name( true, false ), get_option( 'blogname' ) ); ?></p>
+	<p><?php printf( __( 'Hi there. This is a notification about your %1$s application on %2$s.', 'wc-vendors' ), wcv_get_vendor_name( true, false ), get_option( 'blogname' ) ); ?></p>
 	<p><?php printf( __( 'Your application is currently: %s', 'wc-vendors' ), $status ); ?></p>
-	<p><?php printf( __( 'Applicant username: %s', 'wc-vendors' ), $user->user_login ); ?></p>
+	<p><?php printf( __( 'Your username: %s', 'wc-vendors' ), $user->user_login ); ?></p>
 
 <?php
 

--- a/templates/emails/vendor-notify-approved.php
+++ b/templates/emails/vendor-notify-approved.php
@@ -20,7 +20,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 	<p><?php echo $content; ?></p>
 
-	<p><?php printf( __( 'Applicant username: %s', 'wc-vendors' ), $user->user_login ); ?></p>
+	<p><?php printf( __( 'Your username: %s', 'wc-vendors' ), $user->user_login ); ?></p>
 <?php
 
 do_action( 'woocommerce_email_footer', $email );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added new email in 'WooCommerce > Settings > Emails' and a template for this email content. This email must be enabled in order to also send notification to admin when approving a user to be a vendor.

Also rephrased the existing vendor notification as some messages seem directed to vendor but sent to vendor.

Closes #578 .

### How to test the changes in this Pull Request:

1. Go to 'WooCommerce > Settings > Emails' and enable the 'Admin notify vendor approved' email. Click 'Manage' for this email to modify the defaults.
2. Go to WordPress admin Users > All Users', click approve for any pending vendor application
3. Check email or email log and an email should be received with a subject like [WC Vendors Free] <username> has been approved to be a vendor'

### Other information:
