### PR TITLE
Fixed: Translated strings saved to database aren't translated on output #579

### DIFF
--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -207,7 +207,6 @@ if ( wcv_is_woocommerce_activated() ) {
 			$locale = apply_filters( 'plugin_locale', $locale, 'wc-vendors' );
 			load_textdomain( 'wc-vendors', WP_LANG_DIR . '/wc-vendors/wc-vendors-' . $locale . '.mo' );
 			load_plugin_textdomain( 'wc-vendors', false, plugin_basename( dirname( __FILE__ ) ) . '/languages/' );
-
 		}
 
 		/**

--- a/classes/admin/class-vendor-admin-dashboard.php
+++ b/classes/admin/class-vendor-admin-dashboard.php
@@ -578,7 +578,7 @@ class WCV_Vendor_Order_Page extends WP_List_Table {
 										'_line_tax',
 										'_vendor_order_item_id',
 										'_vendor_commission',
-										get_option( 'wcvendors_label_sold_by' ),
+										__( get_option( 'wcvendors_label_sold_by' ), 'wc-vendors' ),
 									)
 								)
 							) ) {

--- a/classes/admin/settings/class-wcv-settings-display.php
+++ b/classes/admin/settings/class-wcv-settings-display.php
@@ -171,7 +171,7 @@ if ( ! class_exists( 'WCVendors_Settings_Display', false ) ) :
 						),
 
 						array(
-							'title'   => sprintf( __( '%s store Info label', 'wc-vendors' ), wcv_get_vendor_name() ),
+							'title'   => sprintf( __( '%s store info label', 'wc-vendors' ), wcv_get_vendor_name() ),
 							'desc'    => sprintf( __( 'The %s store info label', 'wc-vendors' ), wcv_get_vendor_name( true, false ) ),
 							'id'      => 'wcvendors_display_label_store_info',
 							'type'    => 'text',

--- a/classes/front/account/class-wc-account-links.php
+++ b/classes/front/account/class-wc-account-links.php
@@ -49,7 +49,7 @@ class WCV_Account_Links extends WCV_Vendor_Signup {
 	 */
 	public function add_account_menu_items( $items ) {
 
-		$become_a_vendor_label = get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ); 
+		$become_a_vendor_label = __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ), 'wc-vendors' );
 
 		$add_items = apply_filters(
 			'wcv_become_a_vendor_string', array(

--- a/classes/front/account/class-wc-account-links.php
+++ b/classes/front/account/class-wc-account-links.php
@@ -49,17 +49,19 @@ class WCV_Account_Links extends WCV_Vendor_Signup {
 	 */
 	public function add_account_menu_items( $items ) {
 
-		$become_a_vendor_label = __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ), 'wc-vendors' );
+		$become_a_vendor_label = __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a', 'wc-vendors' ) ), 'wc-vendors' );
 
 		$add_items = apply_filters(
-			'wcv_become_a_vendor_string', array(
+			'wcv_become_a_vendor_string',
+			array(
 				'become-a-vendor' => sprintf( __( '%s %s', 'wc-vendors' ), $become_a_vendor_label, wcv_get_vendor_name() )
 			)
 		);
-		// slice the array so the logout link goes at the end of the list
+
+		// slice the array so the logout link goes at the end of the list.
 		$first_part = array_slice( $items, 0, count( $items ) - 1, true );
 		$last_part  = array_slice( $items, count( $items ) - 1, true );
-		// put the arrays together putting the logout link at the end
+		// put the arrays together putting the logout link at the end.
 		$items = $first_part + $add_items + $last_part;
 
 		return $items;

--- a/classes/front/class-vendor-cart.php
+++ b/classes/front/class-vendor-cart.php
@@ -37,8 +37,8 @@ class WCV_Vendor_Cart {
 		$product_id        = $cart_item['product_id'];
 		$post              = get_post( $product_id );
 		$vendor_id         = $post->post_author;
-		$sold_by_label     = get_option( 'wcvendors_label_sold_by' );
-		$sold_by_separator = get_option( 'wcvendors_label_sold_by_separator' );
+		$sold_by_label     = __( get_option( 'wcvendors_label_sold_by' ), 'wc-vendors' );
+		$sold_by_separator = __( get_option( 'wcvendors_label_sold_by_separator' ), 'wc-vendors' );
 		$sold_by           = WCV_Vendors::is_vendor( $vendor_id )
 			? sprintf( '<a href="%s" target="_TOP">%s </a>', WCV_Vendors::get_vendor_shop_page( $vendor_id ), WCV_Vendors::get_vendor_sold_by( $vendor_id ) )
 			: get_bloginfo( 'name' );
@@ -58,8 +58,8 @@ class WCV_Vendor_Cart {
 	public static function sold_by_meta() {
 
 		$vendor_id         = get_the_author_meta( 'ID' );
-		$sold_by_label     = get_option( 'wcvendors_label_sold_by' );
-		$sold_by_separator = get_option( 'wcvendors_label_sold_by_separator' );
+		$sold_by_label     = __( get_option( 'wcvendors_label_sold_by' ), 'wc-vendors' );
+		$sold_by_separator = __( get_option( 'wcvendors_label_sold_by_separator' ), 'wc-vendors' );
 		$sold_by           = WCV_Vendors::is_vendor( $vendor_id )
 			? sprintf( '<a href="%s" class="wcvendors_cart_sold_by_meta">%s</a>', WCV_Vendors::get_vendor_shop_page( $vendor_id ), WCV_Vendors::get_vendor_sold_by( $vendor_id ) )
 			: get_bloginfo( 'name' );

--- a/classes/front/class-vendor-shop.php
+++ b/classes/front/class-vendor-shop.php
@@ -207,8 +207,8 @@ class WCV_Vendor_Shop {
 	public static function template_loop_sold_by( $product_id ) {
 
 		$vendor_id         = WCV_Vendors::get_vendor_from_product( $product_id );
-		$sold_by_label     = get_option( 'wcvendors_label_sold_by' );
-		$sold_by_separator = get_option( 'wcvendors_label_sold_by_separator' );
+		$sold_by_label     = __( get_option( 'wcvendors_label_sold_by' ), 'wc-vendors' );
+		$sold_by_separator = __( get_option( 'wcvendors_label_sold_by_separator' ), 'wc-vendors' );
 		$sold_by           = WCV_Vendors::is_vendor( $vendor_id )
 			? sprintf( '<a href="%s">%s</a>', WCV_Vendors::get_vendor_shop_page( $vendor_id ), WCV_Vendors::get_vendor_sold_by( $vendor_id ) )
 			: get_bloginfo( 'name' );
@@ -339,7 +339,7 @@ class WCV_Vendor_Shop {
 			$cart_item     = $cart[ $cart_item_key ];
 			$product_id    = $cart_item['product_id'];
 			$vendor_id     = WCV_Vendors::get_vendor_from_product( $product_id );
-			$sold_by_label = get_option( 'wcvendors_label_sold_by' );
+			$sold_by_label = __( get_option( 'wcvendors_label_sold_by' ), 'wc-vendors' );
 			$sold_by       = WCV_Vendors::is_vendor( $vendor_id ) ? sprintf( WCV_Vendors::get_vendor_sold_by( $vendor_id ) ) : get_bloginfo( 'name' );
 
 			$item->add_meta_data( apply_filters( 'wcvendors_sold_by_in_email', $sold_by_label ), $sold_by, true );

--- a/classes/front/class-vendor-shop.php
+++ b/classes/front/class-vendor-shop.php
@@ -111,7 +111,7 @@ class WCV_Vendor_Shop {
 			$has_html    = get_user_meta( $post->post_author, 'pv_shop_html_enabled', true );
 			$global_html = get_option( 'wcvendors_display_shop_description_html' );
 
-			$seller_info_label = get_option( 'wcvendors_display_label_store_info' );
+			$seller_info_label = __( get_option( 'wcvendors_display_label_store_info' ), 'wc-vendors' );
 
 			// Run the built in WordPress oEmbed on the seller info if html is enabled.
 			if ( $global_html || $has_html ) {

--- a/classes/front/signup/class-vendor-signup.php
+++ b/classes/front/signup/class-vendor-signup.php
@@ -42,7 +42,7 @@ class WCV_Vendor_Signup {
 	 */
 	public function vendor_option() {
 
-		$become_a_vendor_label = strtolower( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ) );  
+		$become_a_vendor_label = strtolower( __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ), 'wc-vendors' ) );
 
 		apply_filters( 'wcvendors_vendor_signup_path', include_once 'views/html-vendor-signup.php' );
 	}

--- a/classes/includes/class-functions.php
+++ b/classes/includes/class-functions.php
@@ -39,7 +39,7 @@ function wcv_get_vendor_name( $singluar = true, $upper_case = true ) {
 	$vendor_singular = get_option( 'wcvendors_vendor_singular', __( 'Vendor', 'wc-vendors' ) );
 	$vendor_plural   = get_option( 'wcvendors_vendor_plural', __( 'Vendors', 'wc-vendors' ) );
 
-	$vendor_label = $singluar ? $vendor_singular : $vendor_plural;
+	$vendor_label = $singluar ? __( $vendor_singular, 'wc-vendors' ) : __( $vendor_plural, 'wc-vendors' );
 	$vendor_label = $upper_case ? ucfirst( $vendor_label ) : lcfirst( $vendor_label );
 
 	return apply_filters( 'wcv_vendor_display_name', $vendor_label, $vendor_singular, $vendor_plural, $singluar, $upper_case );

--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -741,8 +741,8 @@ class WCV_Shortcodes {
 		$atts = shortcode_atts(			
 			array(
 				'vendor_id'         => get_the_author_meta( 'ID' ),
-				'sold_by_label'     => get_option( 'wcvendors_label_sold_by' ),
-				'sold_by_separator' => get_option( 'wcvendors_label_sold_by_separator' ),
+				'sold_by_label'     => __( get_option( 'wcvendors_label_sold_by' ), 'wc-vendors' ),
+				'sold_by_separator' => __( get_option( 'wcvendors_label_sold_by_separator' ), 'wc-vendors' ),
 			),
 			$atts,
 			'wcv_sold_by'


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Wrapped all labels in the WordPress translation functions to ensiure labels retrived from database go through i18n functions to be checked against translations before being output on the page.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #579 .

### How to test the changes in this Pull Request:

1. Go to 'WC Vendors > Settings > Display > Labels' and change any of the labels
2. Edit the translation file for the current locale on your site to Include the translations for the new labels.
3. Check the pages where those labels are displayed, the translations should be displayed instead of the default labels.

### Other information:

You may need to get new tstrings from the updated .pot file in this PR: https://github.com/wcvendors/wcvendors/pull/585

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
