### PR TITLE
Fixed: Vendors can select featured #583

### DIFF
--- a/assets/js/wcv-admin-quick-edit.js
+++ b/assets/js/wcv-admin-quick-edit.js
@@ -31,4 +31,14 @@ jQuery(function(){
         }
 
     });
+
+    jQuery( document ).ready( function() {
+        var $inputFeatured = $( '.featured input[name="_featured"]' );
+        var $selectFetured = $( 'select.featured' ).closest( 'label' );
+
+        if ( wcv_quick_edit_params.allow_featured == 'no' ) {
+            $inputFeatured.parent().hide();
+            $selectFetured.hide();
+        }
+    });
 });

--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -308,6 +308,13 @@ if ( wcv_is_woocommerce_activated() ) {
 			switch ( $screen->id ) {
 				case 'edit-product':
 					wp_enqueue_script( 'wcv_quick-edit', wcv_assets_url . 'js/wcv-admin-quick-edit.js', array( 'jquery' ), WCV_VERSION );
+					wp_localize_script(
+						'wcv_quick-edit',
+						'wcv_quick_edit_params',
+						array(
+							'allow_featured' => apply_filters( 'wcvendors_capability_allow_product_featured', get_option( 'wcvendors_capability_product_featured', 'no' ) ),
+						)
+					);
 					break;
 				case 'wc-vendors_page_wcv-commissions':
 					wp_register_script( 'wcv_admin_commissions', wcv_assets_url . 'js/admin/wcv-admin-commissions.js', array( 'jquery' ), WCV_VERSION , true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Added a script to check if the capability is disabled for the user and then hide the inputs so that the vendor cannot be able to select if they don't have the capability.

Closes #583  .

### How to test the changes in this Pull Request:

1. Edit option  'WC Vendors > Settings > Capabilities > Products - Featured Products'. Uncheck (if checked or leave unchecked) the option to disallow vendor to choose featured products, save the settings.
2. As a vendor add new product or view products on the vendor dashboard which will redirect to the WordPress Admin dashboard.
3. Using Quick Edit or 'Bulk Action > Edit'. If the 'Featured Products' in step 1 is not checked then the 'Featured' option in Quick Edit or Bulk Actions > Edit must not be visible.
4. Undo step 1, if the option is now checked, then the Featured options in Quick Edit and Bulk Actions > Edit must be visible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
