### PR TITLE
Added: New order item argument for commission calculation for 1085

### DIFF
--- a/classes/admin/class-vendor-reports.php
+++ b/classes/admin/class-vendor-reports.php
@@ -89,7 +89,7 @@ class WCV_Vendor_Reports {
 				continue;
 			} else {
 				if ( ! empty( $order->line_total ) ) {
-					$orders[ $key ]->line_total = WCV_Commission::calculate_commission( $order->line_total, $order->product_id, $order, $order->qty, $item );
+					$orders[ $key ]->line_total = WCV_Commission::calculate_commission( $order->line_total, $order->product_id, $order, $order->qty );
 				}
 			}
 		}

--- a/classes/admin/class-vendor-reports.php
+++ b/classes/admin/class-vendor-reports.php
@@ -67,7 +67,9 @@ class WCV_Vendor_Reports {
 	/**
 	 * Filter products based on current vendor
 	 *
-	 * @param unknown $orders
+	 * @version 2.1.14
+	 * @since   2.0.0
+	 * @param unknown $orders List of orders.
 	 *
 	 * @return unknown
 	 */
@@ -87,7 +89,7 @@ class WCV_Vendor_Reports {
 				continue;
 			} else {
 				if ( ! empty( $order->line_total ) ) {
-					$orders[ $key ]->line_total = WCV_Commission::calculate_commission( $order->line_total, $order->product_id, $order, $order->qty );
+					$orders[ $key ]->line_total = WCV_Commission::calculate_commission( $order->line_total, $order->product_id, $order, $order->qty, $item );
 				}
 			}
 		}

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -346,23 +346,6 @@ class WCV_Commission {
 	 */
 	public static function calculate_commission( $product_price, $product_id, $order, $qty, $item = array() ) {
 
-		if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
-			$coupons = $order->get_used_coupons();
-
-			if ( count( $coupons ) > 1 ) {
-				$coupon_action = apply_filters( 'wcv_commision_coupon_action', 'yes' );
-				if ( 'yes' === $coupon_action ) {
-					$product_price = $item->get_total();
-				} elseif ( 'no' === $coupon_action ) {
-					$product_price = $item->get_subtotal();
-				}
-			} else {
-				$product_price = $item->get_total();
-			}
-
-			$product_id = $item->get_id();
-		}
-
 		$commission_rate = self::get_commission_rate( $product_id );
 		$commission      = $product_price * ( $commission_rate / 100 );
 		$commission      = round( $commission, 2 );

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -347,8 +347,20 @@ class WCV_Commission {
 	public static function calculate_commission( $product_price, $product_id, $order, $qty, $item = array() ) {
 
 		if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
-			$product_price = $item->get_total();
-			$product_id    = $item->get_id();
+			$coupons = $order->get_used_coupons();
+
+			if ( count( $coupons ) > 1 ) {
+				$coupon_action = apply_filters( 'wcv_commision_coupon_action', 'yes' );
+				if ( 'yes' === $coupon_action ) {
+					$product_price = $item->get_total();
+				} elseif ( 'no' === $coupon_action ) {
+					$product_price = $item->get_subtotal();
+				}
+			} else {
+				$product_price = $item->get_total();
+			}
+
+			$product_id = $item->get_id();
 		}
 
 		$commission_rate = self::get_commission_rate( $product_id );

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -338,10 +338,10 @@ class WCV_Commission {
 	 * @version 2.1.14
 	 * @since   2.0.0
 	 * @param float    $product_price The product price.
-	 * @param int      $product_id The product id.
-	 * @param WC_Order $order The WooCommerce order.
-	 * @param int      $qty The product quantity.
-	 * @param mixed    $item The order item. Optional, default array().
+	 * @param int      $product_id    The product id.
+	 * @param WC_Order $order         The WooCommerce order.
+	 * @param int      $qty           The product quantity.
+	 * @param mixed    $item          The order item. Optional, default array().
 	 * @return float
 	 */
 	public static function calculate_commission( $product_price, $product_id, $order, $qty, $item = array() ) {

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -335,18 +335,27 @@ class WCV_Commission {
 	/**
 	 * Commission due for a product based on a rate and price
 	 *
-	 * @param float   $product_price
-	 * @param unknown $product_id
-	 *
+	 * @version 2.1.14
+	 * @since   2.0.0
+	 * @param float    $product_price The product price.
+	 * @param int      $product_id The product id.
+	 * @param WC_Order $order The WooCommerce order.
+	 * @param int      $qty The product quantity.
+	 * @param mixed    $item The order item. Optional, default array().
 	 * @return float
 	 */
-	public static function calculate_commission( $product_price, $product_id, $order, $qty ) {
+	public static function calculate_commission( $product_price, $product_id, $order, $qty, $item = array() ) {
 
-		$commission_rate = WCV_Commission::get_commission_rate( $product_id );
+		if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
+			$product_price = $item->get_total();
+			$product_id    = $item->get_id();
+		}
+
+		$commission_rate = self::get_commission_rate( $product_id );
 		$commission      = $product_price * ( $commission_rate / 100 );
 		$commission      = round( $commission, 2 );
 
-		return apply_filters( 'wcv_commission_rate', $commission, $product_id, $product_price, $order, $qty );
+		return apply_filters( 'wcv_commission_rate', $commission, $product_id, $product_price, $order, $qty, $item );
 	}
 
 

--- a/classes/class-vendors.php
+++ b/classes/class-vendors.php
@@ -128,7 +128,7 @@ class WCV_Vendors {
 			$give_tax_override      = get_user_meta( $author, 'wcv_give_vendor_tax', true );
 			$give_shipping_override = get_user_meta( $author, 'wcv_give_vendor_shipping', true );
 			$is_vendor              = WCV_Vendors::is_vendor( $author );
-			$commission             = $is_vendor ? WCV_Commission::calculate_commission( $order_item['line_subtotal'], $product_id, $order, $order_item['qty'] ) : 0;
+			$commission             = $is_vendor ? WCV_Commission::calculate_commission( $order_item['line_subtotal'], $product_id, $order, $order_item['qty'], $order_item ) : 0;
 			$tax                    = ! empty( $order_item['line_tax'] ) ? (float) $order_item['line_tax'] : 0;
 			$order_id               = $order->get_id();
 
@@ -562,7 +562,7 @@ class WCV_Vendors {
 						'tax'          => $item['line_tax'],
 						'subtotal_tax' => $item['line_subtotal_tax'],
 						'tax_data'     => maybe_unserialize( $item['line_tax_data'] ),
-						'commission'   => WCV_Commission::calculate_commission( $item['line_subtotal'], $item['product_id'], $order, $item['qty'] ),
+						'commission'   => WCV_Commission::calculate_commission( $item['line_subtotal'], $item['product_id'], $order, $item['qty'], $item ),
 					);
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added a new argument to pass the order item from which commissions is calculated. This will allow commission to be calculated from the item instead of product price.

Required by https://github.com/wcvendors/wcvendors-pro/pull/1085.

### Testing

1. Checkout this branch and test https://github.com/wcvendors/wcvendors-pro/pull/1085

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?