### PR TITLE
Fixed:  Low/out stock emails not sending #593 

### DIFF
--- a/classes/admin/emails/class-emails.php
+++ b/classes/admin/emails/class-emails.php
@@ -141,14 +141,14 @@ class WCV_Emails {
 	public function vendor_stock_email( $emails, $product ) {
 
 		if ( ! is_a( $product, 'WC_Product' ) ) {
-			return;
+			return $emails;
 		}
 
 		$post = get_post( $product->get_id() );
 
 		if ( WCV_Vendors::is_vendor( $post->post_author ) ) {
 			$vendor_data  = get_userdata( $post->post_author );
-			$vendor_email = $vendor_data->user_email;
+			$vendor_email = trim( $vendor_data->user_email );
 			$emails       .= ',' . $vendor_email;
 		}
 
@@ -164,9 +164,9 @@ class WCV_Emails {
 	 */
 	public function vendor_low_stock_email( $emails, $product ) {
 		if ( 'no' === get_option( 'wcvendors_notify_low_stock', 'yes' ) ) {
-			return;
+			return $emails;
 		}
-		$this->vendor_stock_email(  $emails, $product );
+		return $this->vendor_stock_email(  $emails, $product );
 	}
 
 	/**
@@ -177,9 +177,9 @@ class WCV_Emails {
 	 */
 	public function vendor_no_stock_email( $emails, $product ) {
 		if ( 'no' === get_option( 'wcvendors_notify_low_stock', 'yes' ) ) {
-			return;
+			return $emails;
 		}
-		$this->vendor_stock_email( $emails, $product );
+		return $this->vendor_stock_email( $emails, $product );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds missing return statements to low stock and out of stock email recipient filters.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #593.

### How to test the changes in this Pull Request:

1. Enable low stock emails
2. Install mail log plugin
3. Trigger low stock emails
4. See the low stock/out of stock emails sending normally. 