### PR TITLE
Fixed: Sold by label spacing on single product page

### DIFF
--- a/classes/front/class-vendor-cart.php
+++ b/classes/front/class-vendor-cart.php
@@ -61,7 +61,7 @@ class WCV_Vendor_Cart {
 		$sold_by           = wcv_get_sold_by_link( $vendor_id, 'wcvendors_cart_sold_by_meta' );
 
 		printf(
-			apply_filters( 'wcvendors_cart_sold_by_meta_template', '%1$s %2$s %3$s<br/>', get_the_ID(), $vendor_id ),
+			apply_filters( 'wcvendors_cart_sold_by_meta_template', '%1$s%2$s %3$s<br/>', get_the_ID(), $vendor_id ),
 			apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ),
 			apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ),
 			$sold_by

--- a/classes/front/class-vendor-cart.php
+++ b/classes/front/class-vendor-cart.php
@@ -60,12 +60,7 @@ class WCV_Vendor_Cart {
 		$sold_by_separator = __( get_option( 'wcvendors_label_sold_by_separator' ), 'wc-vendors' );
 		$sold_by           = wcv_get_sold_by_link( $vendor_id, 'wcvendors_cart_sold_by_meta' );
 
-		printf(
-			apply_filters( 'wcvendors_cart_sold_by_meta_template', '%1$s%2$s %3$s<br/>', get_the_ID(), $vendor_id ),
-			apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ),
-			apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ),
-			$sold_by
-		);
+		echo wcv_get_vendor_sold_by( $vendor_id );
 	}
 
 }

--- a/classes/includes/wcv-template-functions.php
+++ b/classes/includes/wcv-template-functions.php
@@ -206,3 +206,22 @@ if ( ! function_exists( 'wcv_get_sold_by_link' )  ){
 
 	}
 }
+
+
+if ( ! function_exists( 'wcv_get_vendor_sold_by') ){
+	function wcv_get_vendor_sold_by( $vendor_id ){
+
+		$sold_by_label     = __( get_option( 'wcvendors_label_sold_by' ), 'wc-vendors' );
+		$sold_by_separator = __( get_option( 'wcvendors_label_sold_by_separator' ), 'wc-vendors' );
+		$sold_by           = wcv_get_sold_by_link( $vendor_id, 'wcvendors_cart_sold_by_meta' );
+
+		$vendor_sold_by = sprintf(
+			apply_filters( 'wcvendors_cart_sold_by_meta_template', '%1$s %2$s %3$s', get_the_ID(), $vendor_id ),
+			apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ),
+			apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ),
+			$sold_by
+		);
+
+		return $vendor_sold_by;
+	}
+}

--- a/templates/front/vendor-sold-by.php
+++ b/templates/front/vendor-sold-by.php
@@ -8,7 +8,7 @@
  *
  * @author        Jamie Madden, WC Vendors
  * @package       WCVendors/Templates/Emails/HTML
- * @version       2.0.0
+ * @version       2.1.17
  *
  *
  * Template Variables available
@@ -26,5 +26,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<small class="wcvendors_sold_by_in_loop"><?php echo apply_filters( 'wcvendors_sold_by_in_loop', $sold_by_label ); ?><?php echo apply_filters( 'wcvendors_sold_by_separator_in_loop', $sold_by_separator ); ?><?php echo $sold_by; ?>
-</small><br/>
+<small class="wcvendors_sold_by_in_loop"><?php echo wcv_get_vendor_sold_by( $vendor_id ); ?></small><br/>


### PR DESCRIPTION
### All Submissions:

* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #597

### How to test the changes in this Pull Request:

1. Sold by label on single product page always had a space after label and separator
2. Check the sold by spacing on all aspects of the site are now universal with no space
<!-- Mark completed items with an [x] -->
