### PR TITLE
Updated: Deprecate vendor_list shortcode argument #595

### DIFF
--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -636,9 +636,9 @@ class WCV_Shortcodes {
 
 		if ( isset( $atts['show_products'] ) ) {
 			wc_deprecated_argument(
-				'show_products',
-				'2.1.16',
-				sprintf( __( 'This argument will be removed in %s', 'wcvendors-pro' ), '3.0.0' )
+				'wcv_vendorslist',
+				'2.1.17',
+				sprintf( __( 'The "show_products" argument will be removed in version %s. Please update to use "has_products".', 'wcvendors-pro' ), '3.0.0' )
 			);
 			$atts['has_products'] = $atts['show_products'];
 			unset( $atts['show_products'] );

--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -634,6 +634,16 @@ class WCV_Shortcodes {
 
 		$html = '';
 
+		if ( isset( $atts['show_products'] ) ) {
+			wc_deprecated_argument(
+				'show_products',
+				'2.1.16',
+				sprintf( __( 'This argument will be removed in %s', 'wcvendors-pro' ), '3.0.0' )
+			);
+			$atts['has_products'] = $atts['show_products'];
+			unset( $atts['show_products'] );
+		}
+
 		extract(
 			shortcode_atts(
 				array(
@@ -641,7 +651,7 @@ class WCV_Shortcodes {
 					'order'         => 'ASC',
 					'per_page'      => '12',
 					'columns'       => '4',
-					'show_products' => 'yes',
+					'has_products' => 'no',
 				), $atts
 			)
 		);
@@ -650,7 +660,7 @@ class WCV_Shortcodes {
 		$offset = ( $paged - 1 ) * $per_page;
 
 		// Hook into the user query to modify the query to return users that have at least one product
-		if ( $show_products == 'yes' ) {
+		if ( $has_products == 'yes' ) {
 			add_action( 'pre_user_query', array( $this, 'vendors_with_products' ) );
 		}
 
@@ -664,7 +674,7 @@ class WCV_Shortcodes {
 			'order'        => $order,
 		);
 
-		if ( $show_products == 'yes' ) {
+		if ( $has_products == 'yes' ) {
 			$vendor_total_args['query_id'] = 'vendors_with_products';
 		}
 
@@ -683,7 +693,7 @@ class WCV_Shortcodes {
 			'number'       => $per_page,
 		);
 
-		if ( $show_products == 'yes' ) {
+		if ( $has_products == 'yes' ) {
 			$vendor_paged_args['query_id'] = 'vendors_with_products';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replace show_products with has_products argument in wcv_pro_vendorslist shortcode. Add a deprecated argument notice to be logged when if the show_products argument is used.

Closes  #595

### How to test the changes in this Pull Request:

1. Add the shortcode [wcv_pro_vendorslist show_products="yes"] to any post/page
2. Visit the post and you should see the vendors list as normal
3. Check debug.log and you should see a message like

Notice: show_products was called with an argument that is <strong>deprecated</strong> since version 2.1.16! This argument will be removed in 3.0.0 in /var/www/html/wp-includes/functions.php

4. Replace the show_products="yes" with has_products="yes" in the shortcode, save the post.
5. View the post. The Vendors list should be displayed as normal.
6. Check debug.log, there should be no new log entry like the in number 3 above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
