### PR TITLE
Fixed: get current page error on setup wizard #640

### DIFF
--- a/classes/admin/views/setup/header.php
+++ b/classes/admin/views/setup/header.php
@@ -16,7 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<title><?php esc_html_e( 'WC Vendors &rsaquo; Setup Wizard', 'wc-vendors' ); ?></title>
 	<?php wp_print_scripts( 'wcv-setup' ); ?>
 	<?php do_action( 'admin_print_styles' ); ?>
-	<?php do_action( 'admin_head' ); ?>
 </head>
 <body class="wcv-setup wp-core-ui">
 <h1 id="wcv-logo"><a href="https://www.wcvendors.com/"><img


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes error output with warnings in the setup wizard

Closes #640.

### How to test the changes in this Pull Request:

Ensure WP_DEBUG is on

1. Go to WC Vendors > Settings  
2. Click on help top right, then setup wizard
3. See error is gone. 


