### PR TITLE
Fix date query bug.

### DIFF
--- a/classes/class-queries.php
+++ b/classes/class-queries.php
@@ -271,8 +271,6 @@ class WCV_Queries {
 		$start_date = WC()->session->get( 'wcv_order_start_date', strtotime( current_time( 'Y-M' ) . '-01' ) );
 		$end_date   = WC()->session->get( 'wcv_order_end_date', strtotime( current_time( 'mysql' ) ) );
 
-		error_log( "End date: $end_date, Start date: $start_date");
-
 		$after  = gmdate( 'Y-m-d', $start_date );
 		$before = gmdate( 'Y-m-d', strtotime( '+1 day', $end_date ) );
 

--- a/classes/class-queries.php
+++ b/classes/class-queries.php
@@ -269,7 +269,9 @@ class WCV_Queries {
 		}
 
 		$start_date = WC()->session->get( 'wcv_order_start_date', strtotime( current_time( 'Y-M' ) . '-01' ) );
-		$end_date   = WC()->session->get( 'wcv_order_end_date', current_time( 'mysql' ) );
+		$end_date   = WC()->session->get( 'wcv_order_end_date', strtotime( current_time( 'mysql' ) ) );
+
+		error_log( "End date: $end_date, Start date: $start_date");
 
 		$after  = gmdate( 'Y-m-d', $start_date );
 		$before = gmdate( 'Y-m-d', strtotime( '+1 day', $end_date ) );

--- a/classes/class-queries.php
+++ b/classes/class-queries.php
@@ -260,19 +260,19 @@ class WCV_Queries {
 	public static function orders_within_range() {
 		global $start_date, $end_date;
 
-		$start_date = WC()->session->get( 'wcv_order_start_date', strtotime( current_time( 'Y-M' ) . '-01' ) );
-		$end_date   = WC()->session->get( 'wcv_order_end_date', current_time( 'timestamp' ) );
-
 		if ( ! empty( $_POST['start_date'] ) ) {
-			WC()->session->set( 'wcv_order_start_date', strtotime( $_POST['start_date'] ) );
+			WC()->session->set( 'wcv_order_start_date', strtotime( sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) ) );
 		}
 
 		if ( ! empty( $_POST['end_date'] ) ) {
-			WC()->session->set( 'wcv_order_end_date', strtotime( $_POST['end_date'] ) );
+			WC()->session->set( 'wcv_order_end_date', strtotime( sanitize_text_field( wp_unslash( $_POST['end_date'] ) ) ) );
 		}
 
-		$after  = date( 'Y-m-d', $start_date );
-		$before = date( 'Y-m-d', strtotime( '+1 day', $end_date ) );
+		$start_date = WC()->session->get( 'wcv_order_start_date', strtotime( current_time( 'Y-M' ) . '-01' ) );
+		$end_date   = WC()->session->get( 'wcv_order_end_date', current_time( 'mysql' ) );
+
+		$after  = gmdate( 'Y-m-d', $start_date );
+		$before = gmdate( 'Y-m-d', strtotime( '+1 day', $end_date ) );
 
 		return apply_filters(
 			'wcvendors_orders_date_range',


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Changes as proposed
> More specifically, I have to reverse the logic for this orders_within_range function so that it would SET the wcv_order_start_date and wcv_order_end_date session variables BEFORE it would GET them.

Closes #645.

### How to test the changes in this Pull Request:

1.  Go to 'Vendor Dashboard > Orders' page
2. Select a 'From:' and 'To:' date to filter the orders and click Show'
3. Check and see the displayed orders match the selected date range.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
