### PR TITLE
Updated: Update filter names in WCV_Shortcodes class #644

### DIFF
--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -87,7 +87,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts ) );
+		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -173,7 +173,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts ) );
+		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -252,7 +252,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts ) );
+		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -329,7 +329,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts ) );
+		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -401,7 +401,7 @@ class WCV_Shortcodes {
 
 		add_filter( 'posts_clauses', array( 'WC_Shortcodes', 'order_by_rating_post_clauses' ) );
 
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts ) );
+		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
 
 		remove_filter( 'posts_clauses', array( 'WC_Shortcodes', 'order_by_rating_post_clauses' ) );
 
@@ -474,7 +474,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts ) );
+		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -568,7 +568,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts ) );
+		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -759,7 +759,7 @@ class WCV_Shortcodes {
 		);
 		extract( $atts );
 
-		$sold_by           = wcv_get_sold_by_link( $vendor_id, 'wcvendors_cart_sold_by_meta' );
+		$sold_by = wcv_get_sold_by_link( $vendor_id, 'wcvendors_cart_sold_by_meta' );
 
 		return apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
 	}

--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -761,7 +761,7 @@ class WCV_Shortcodes {
 
 		$sold_by = wcv_get_sold_by_link( $vendor_id, 'wcvendors_cart_sold_by_meta' );
 
-		return apply_filters( 'wcv_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcv_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
+		return apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
 	}
 
 }

--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -761,7 +761,7 @@ class WCV_Shortcodes {
 
 		$sold_by = wcv_get_sold_by_link( $vendor_id, 'wcvendors_cart_sold_by_meta' );
 
-		return apply_filters( 'wcvendors_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcvendors_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
+		return apply_filters( 'wcv_cart_sold_by_meta', $sold_by_label, get_the_ID(), $vendor_id ) . '&nbsp;' . apply_filters( 'wcv_cart_sold_by_meta_separator', $sold_by_separator, get_the_ID(), $vendor_id ) . '&nbsp;' . $sold_by . '<br/>';
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updated all filters in the WCV_Shortcodes to use the wcvendors prefix 'wcv'

Closes #644 .

### How to test the changes in this Pull Request:

1. For each of the filters add, apply them using the code snippet below, replacing FILTER_NAME with each of the filters
2. Visit the Vendors list page and see if the vendors displayed are matching the modified query args.

```
add_filter(
	'FILTER_NAME',
	function ( $args, $atts ) {
		// modify $args
		return $args;
	}
);
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
