### PR TITLE
Fixed: Timezone display for commissions #625

### DIFF
--- a/classes/admin/class-admin-reports.php
+++ b/classes/admin/class-admin-reports.php
@@ -79,8 +79,8 @@ class WCV_Admin_Reports {
 
 		$commission_status_labels = WCV_Commission::commission_status();
 
-		$start_date = ! empty( $_POST['start_date'] ) ? $_POST['start_date'] : strtotime( date( 'Ymd', strtotime( date( 'Ym', current_time( 'timestamp' ) ) . '01' ) ) );
-		$end_date   = ! empty( $_POST['end_date'] ) ? $_POST['end_date'] : strtotime( date( 'Ymd', current_time( 'timestamp' ) ) );
+		$start_date = ! empty( $_POST['start_date'] ) ? $_POST['start_date'] : strtotime( gmdate( 'Ymd', strtotime( gmdate( 'Ym', current_time( 'timestamp' ) ) . '01' ) ) );
+		$end_date   = ! empty( $_POST['end_date'] ) ? $_POST['end_date'] : strtotime( gmdate( 'Ymd', current_time( 'timestamp' ) ) );
 
 		if ( ! empty( $_POST['start_date'] ) ) {
 			$start_date = strtotime( $_POST['start_date'] );
@@ -90,8 +90,8 @@ class WCV_Admin_Reports {
 			$end_date = strtotime( $_POST['end_date'] );
 		}
 
-		$after  = date( 'Y-m-d', $start_date );
-		$before = date( 'Y-m-d', strtotime( '+1 day', $end_date ) );
+		$after  = gmdate( 'Y-m-d', $start_date );
+		$before = gmdate( 'Y-m-d', strtotime( '+1 day', $end_date ) );
 
 		$commission_due = $wpdb->get_var(
 			"
@@ -122,11 +122,11 @@ class WCV_Admin_Reports {
 		<form method="post" action="">
 			<p><label for="from"><?php _e( 'From:', 'wc-vendors' ); ?></label>
 				<input type="text" size="9" placeholder="yyyy-mm-dd"
-				       value="<?php echo esc_attr( date( 'Y-m-d', $start_date ) ); ?>" name="start_date"
+				       value="<?php echo esc_attr( gmdate( 'Y-m-d', $start_date ) ); ?>" name="start_date"
 				       class="range_datepicker from" id="from"/>
 				<label for="to"><?php _e( 'To:', 'wc-vendors' ); ?></label>
 				<input type="text" size="9" placeholder="yyyy-mm-dd"
-				       value="<?php echo esc_attr( date( 'Y-m-d', $end_date ) ); ?>" name="end_date"
+				       value="<?php echo esc_attr( gmdate( 'Y-m-d', $end_date ) ); ?>" name="end_date"
 				       class="range_datepicker to" id="to"/>
 				<input type="submit" class="button" value="<?php _e( 'Show', 'wc-vendors' ); ?>"/></p>
 		</form>
@@ -271,8 +271,8 @@ class WCV_Admin_Reports {
 		$latest_woo = version_compare( $woocommerce->version, '2.3', '>' );
 
 		$first_year   = $wpdb->get_var( "SELECT time FROM {$wpdb->prefix}pv_commission ORDER BY time ASC LIMIT 1;" );
-		$first_year   = $first_year ? date( 'Y', strtotime( $first_year ) ) : date( 'Y' );
-		$current_year = isset( $_POST['show_year'] ) ? $_POST['show_year'] : date( 'Y', current_time( 'timestamp' ) );
+		$first_year   = $first_year ? gmdate( 'Y', strtotime( $first_year ) ) : gmdate( 'Y' );
+		$current_year = isset( $_POST['show_year'] ) ? $_POST['show_year'] : gmdate( 'Y', current_time( 'timestamp' ) );
 		$start_date   = strtotime( $current_year . '0101' );
 
 		$vendors         = get_users( array( 'role' => 'vendor' ) );
@@ -286,7 +286,7 @@ class WCV_Admin_Reports {
 			<label for="show_year"><?php _e( 'Show:', 'wc-vendors' ); ?></label>
 			<select name="show_year" id="show_year">
 				<?php
-				for ( $i = $first_year; $i <= date( 'Y' ); $i ++ ) {
+				for ( $i = $first_year; $i <= gmdate( 'Y' ); $i ++ ) {
 					printf( '<option value="%s" %s>%s</option>', $i, selected( $current_year, $i, false ), $i );
 				}
 				?>
@@ -374,12 +374,12 @@ class WCV_Admin_Reports {
 			$date_sql     = " AND date_format(`time`,'%%Y%%m') = %d";
 
 			for ( $count = 0; $count < 12; $count ++ ) {
-				$time = strtotime( date( 'Ym', strtotime( '+ ' . $count . ' MONTH', $start_date ) ) . '01' );
+				$time = strtotime( gmdate( 'Ym', strtotime( '+ ' . $count . ' MONTH', $start_date ) ) . '01' );
 				if ( $time > current_time( 'timestamp' ) ) {
 					continue;
 				}
 
-				$month = date( 'Ym', strtotime( date( 'Ym', strtotime( '+ ' . $count . ' MONTH', $start_date ) ) . '01' ) );
+				$month = gmdate( 'Ym', strtotime( gmdate( 'Ym', strtotime( '+ ' . $count . ' MONTH', $start_date ) ) . '01' ) );
 
 				$fetch_results = $wpdb->prepare( $sql . $filter . $date_sql, $month );
 
@@ -391,7 +391,7 @@ class WCV_Admin_Reports {
 				$paid     = $wpdb->get_var( $wpdb->prepare( $paid_sql . $date_sql, $month ) );
 				$reversed = $wpdb->get_var( $wpdb->prepare( $reversed_sql . $date_sql, $month ) );
 
-				$commissions[ date( 'M', strtotime( $month . '01' ) ) ] = array(
+				$commissions[ gmdate( 'M', strtotime( $month . '01' ) ) ] = array(
 					'commission' => $commission,
 					'tax'        => $tax,
 					'shipping'   => $shipping,
@@ -479,8 +479,8 @@ class WCV_Admin_Reports {
 
 		global $wpdb;
 
-		$total_start_date  = ! empty( $_POST['total_start_date'] ) ? $_POST['total_start_date'] : strtotime( date( 'Ymd', strtotime( date( 'Ym', current_time( 'timestamp' ) ) . '01' ) ) );
-		$total_end_date    = ! empty( $_POST['total_end_date'] ) ? $_POST['total_end_date'] : strtotime( date( 'Ymd', current_time( 'timestamp' ) ) );
+		$total_start_date  = ! empty( $_POST['total_start_date'] ) ? $_POST['total_start_date'] : strtotime( gmdate( 'Ymd', strtotime( gmdate( 'Ym', current_time( 'timestamp' ) ) . '01' ) ) );
+		$total_end_date    = ! empty( $_POST['total_end_date'] ) ? $_POST['total_end_date'] : strtotime( gmdate( 'Ymd', current_time( 'timestamp' ) ) );
 		$commission_status = ! empty( $_POST['commission_status'] ) ? $_POST['commission_status'] : 'due';
 		$date_sql          = ( ! empty( $_POST['total_start_date'] ) && ! empty( $_POST['total_end_date'] ) ) ? " time BETWEEN '$total_start_date 00:00:00' AND '$total_end_date 23:59:59' AND" : '';
 
@@ -504,11 +504,11 @@ class WCV_Admin_Reports {
 		<form method="post" action="">
 			<p><label for="from"><?php _e( 'From:', 'wc-vendors' ); ?></label>
 				<input type="text" size="9" placeholder="yyyy-mm-dd"
-				       value="<?php echo esc_attr( date( 'Y-m-d', $total_start_date ) ); ?>" name="total_start_date"
+				       value="<?php echo esc_attr( gmdate( 'Y-m-d', $total_start_date ) ); ?>" name="total_start_date"
 				       class="range_datepicker from" id="from"/>
 				<label for="to"><?php _e( 'To:', 'wc-vendors' ); ?></label>
 				<input type="text" size="9" placeholder="yyyy-mm-dd"
-				       value="<?php echo esc_attr( date( 'Y-m-d', $total_end_date ) ); ?>" name="total_end_date"
+				       value="<?php echo esc_attr( gmdate( 'Y-m-d', $total_end_date ) ); ?>" name="total_end_date"
 				       class="range_datepicker to" id="to"/>
 
 				<select name="commission_status">

--- a/classes/admin/class-admin-reports.php
+++ b/classes/admin/class-admin-reports.php
@@ -272,7 +272,7 @@ class WCV_Admin_Reports {
 
 		$first_year   = $wpdb->get_var( "SELECT time FROM {$wpdb->prefix}pv_commission ORDER BY time ASC LIMIT 1;" );
 		$first_year   = $first_year ? gmdate( 'Y', strtotime( $first_year ) ) : gmdate( 'Y' );
-		$current_year = isset( $_POST['show_year'] ) ? $_POST['show_year'] : gmdate( 'Y', current_time( 'timestamp' ) );
+		$current_year = isset( $_POST['show_year'] ) ? $_POST['show_year'] : gmdate( 'Y', current_time( 'mysql' ) );
 		$start_date   = strtotime( $current_year . '0101' );
 
 		$vendors         = get_users( array( 'role' => 'vendor' ) );
@@ -479,8 +479,8 @@ class WCV_Admin_Reports {
 
 		global $wpdb;
 
-		$total_start_date  = ! empty( $_POST['total_start_date'] ) ? $_POST['total_start_date'] : strtotime( gmdate( 'Ymd', strtotime( gmdate( 'Ym', current_time( 'timestamp' ) ) . '01' ) ) );
-		$total_end_date    = ! empty( $_POST['total_end_date'] ) ? $_POST['total_end_date'] : strtotime( gmdate( 'Ymd', current_time( 'timestamp' ) ) );
+		$total_start_date  = ! empty( $_POST['total_start_date'] ) ? $_POST['total_start_date'] : strtotime( gmdate( 'Ymd', strtotime( gmdate( 'Ym', current_time( 'mysql' ) ) . '01' ) ) );
+		$total_end_date    = ! empty( $_POST['total_end_date'] ) ? $_POST['total_end_date'] : strtotime( gmdate( 'Ymd', current_time( 'mysql' ) ) );
 		$commission_status = ! empty( $_POST['commission_status'] ) ? $_POST['commission_status'] : 'due';
 		$date_sql          = ( ! empty( $_POST['total_start_date'] ) && ! empty( $_POST['total_end_date'] ) ) ? " time BETWEEN '$total_start_date 00:00:00' AND '$total_end_date 23:59:59' AND" : '';
 

--- a/classes/admin/class-wcv-admin-setup.php
+++ b/classes/admin/class-wcv-admin-setup.php
@@ -220,7 +220,7 @@ class WCV_Admin_Setup {
 
 			$exporter = new WCV_Commissions_CSV_Export();
 
-			$date = date( 'Y-M-d' );
+			$date = gmdate( 'Y-M-d' );
 
 			if ( ! empty( $_GET['com_status'] ) ) { // WPCS: input var ok.
 				$exporter->set_filename( 'wcv_commissions_' . wp_unslash( $_GET['com_status'] ) . '-' . $date . '.csv' ); // WPCS: input var ok, sanitization ok.
@@ -245,7 +245,7 @@ class WCV_Admin_Setup {
 
 			$exporter = new WCV_Commissions_Sum_CSV_Export();
 
-			$date = date( 'Y-M-d' );
+			$date = gmdate( 'Y-M-d' );
 
 			if ( ! empty( $_GET['com_status'] ) ) { // WPCS: input var ok.
 				$exporter->set_filename( 'wcv_commissions_sum_' . wp_unslash( $_GET['com_status'] ) . '-' . $date . '.csv' ); // WPCS: input var ok, sanitization ok.

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -171,7 +171,7 @@ class WCV_Commission {
 					'total_shipping' => ! empty( $insert_due[ $product_id ]['total_shipping'] ) ? ( $detail['shipping'] + $insert_due[ $product_id ]['total_shipping'] ) : $detail['shipping'],
 					'tax'            => ! empty( $insert_due[ $product_id ]['tax'] ) ? ( $detail['tax'] + $insert_due[ $product_id ]['tax'] ) : $detail['tax'],
 					'qty'            => ! empty( $insert_due[ $product_id ]['qty'] ) ? ( $detail['qty'] + $insert_due[ $product_id ]['qty'] ) : $detail['qty'],
-					'time'           => date( 'Y-m-d H:i:s', strtotime( $order_date ) ),
+					'time'           => gmdate( 'Y-m-d H:i:s', strtotime( $order_date ) ),
 				);
 			}
 

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -171,7 +171,7 @@ class WCV_Commission {
 					'total_shipping' => ! empty( $insert_due[ $product_id ]['total_shipping'] ) ? ( $detail['shipping'] + $insert_due[ $product_id ]['total_shipping'] ) : $detail['shipping'],
 					'tax'            => ! empty( $insert_due[ $product_id ]['tax'] ) ? ( $detail['tax'] + $insert_due[ $product_id ]['tax'] ) : $detail['tax'],
 					'qty'            => ! empty( $insert_due[ $product_id ]['qty'] ) ? ( $detail['qty'] + $insert_due[ $product_id ]['qty'] ) : $detail['qty'],
-					'time'           => gmdate( 'Y-m-d H:i:s', strtotime( $order_date ) ),
+					'time'           => date( 'Y-m-d H:i:s', strtotime( $order_date ) ),
 				);
 			}
 

--- a/templates/dashboard/date-picker.php
+++ b/templates/dashboard/date-picker.php
@@ -18,11 +18,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p>
 		<label style="display:inline;" for="from"><?php _e( 'From:', 'wc-vendors' ); ?></label>
 		<input class="date-pick" type="date" name="start_date" id="from"
-		       value="<?php echo esc_attr( date( 'Y-m-d', $start_date ) ); ?>"/>
+		       value="<?php echo esc_attr( gmdate( 'Y-m-d', $start_date ) ); ?>"/>
 
 		<label style="display:inline;" for="to"><?php _e( 'To:', 'wc-vendors' ); ?></label>
 		<input type="date" class="date-pick" name="end_date" id="to"
-		       value="<?php echo esc_attr( date( 'Y-m-d', $end_date ) ); ?>"/>
+		       value="<?php echo esc_attr( gmdate( 'Y-m-d', $end_date ) ); ?>"/>
 
 		<input type="submit" class="btn btn-inverse btn-small" style="float:none;"
 		       value="<?php _e( 'Show', 'wc-vendors' ); ?>"/>

--- a/templates/orders/shipping/shipping-form.php
+++ b/templates/orders/shipping/shipping-form.php
@@ -85,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			'placeholder' => 'YYYY-MM-DD',
 			'description' => '',
 			'class'       => 'date-picker-field',
-			'value'       => ( $date = get_post_meta( $order_id, '_date_shipped', true ) ) ? date( 'Y-m-d', $date ) : '',
+			'value'       => ( $date = get_post_meta( $order_id, '_date_shipped', true ) ) ? gmdate( 'Y-m-d', $date ) : '',
 		)
 	);
 

--- a/templates/orders/shipping/shipping-form.php
+++ b/templates/orders/shipping/shipping-form.php
@@ -14,15 +14,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<form method="post" name="track_shipment" id="track-shipment_<?php echo $order_id; ?>">
+<form method="post" name="track_shipment" id="track-shipment_<?php echo esc_attr( $order_id ); ?>">
 
 	<?php
 	wp_nonce_field( 'track-shipment' );
 
-	// Providers
-	echo '<p class="form-field tracking_provider_field"><label for="tracking_provider">' . __( 'Provider:', 'wc_shipment_tracking' ) . '</label><br/><select id="tracking_provider" name="tracking_provider" class="tracking_provider" style="width:100%;">';
+	// Providers.
+	echo '<p class="form-field tracking_provider_field"><label for="tracking_provider">' . esc_attr__( 'Provider:', 'wc-vendors' ) . '</label><br/><select id="tracking_provider" name="tracking_provider" class="tracking_provider" style="width:100%;">';
 
-	echo '<option value="">' . __( 'Custom Provider', 'wc_shipment_tracking' ) . '</option>';
+	echo '<option value="">' . esc_attr__( 'Custom Provider', 'wc-vendors' ) . '</option>';
 
 	$selected_provider = get_post_meta( $order_id, '_tracking_provider', true );
 
@@ -48,7 +48,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	woocommerce_wp_text_input(
 		array(
 			'id'            => 'custom_tracking_provider_name',
-			'label'         => __( 'Provider Name:', 'wc_shipment_tracking' ),
+			'label'         => __( 'Provider Name:', 'wc-vendors' ),
 			'wrapper_class' => $class,
 			'placeholder'   => '',
 			'description'   => '',
@@ -59,7 +59,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	woocommerce_wp_text_input(
 		array(
 			'id'          => 'tracking_number',
-			'label'       => __( 'Tracking number:', 'wc_shipment_tracking' ),
+			'label'       => __( 'Tracking number:', 'wc-vendors' ),
 			'placeholder' => '',
 			'description' => '',
 			'value'       => get_post_meta( $order_id, '_tracking_number', true ),
@@ -69,7 +69,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	woocommerce_wp_text_input(
 		array(
 			'id'            => 'custom_tracking_url',
-			'label'         => __( 'Tracking link:', 'wc_shipment_tracking' ),
+			'label'         => __( 'Tracking link:', 'wc-vendors' ),
 			'placeholder'   => 'http://',
 			'wrapper_class' => $class,
 			'description'   => '',
@@ -81,7 +81,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		array(
 			'type'        => 'date',
 			'id'          => 'date_shipped',
-			'label'       => __( 'Date shipped:', 'wc_shipment_tracking' ),
+			'label'       => __( 'Date shipped:', 'wc-vendors' ),
 			'placeholder' => 'YYYY-MM-DD',
 			'description' => '',
 			'class'       => 'date-picker-field',
@@ -89,18 +89,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 		)
 	);
 
-	// Live preview
-	echo '<p class="preview_tracking_link" style="display:none;">' . __( 'Preview:', 'wc_shipment_tracking' ) . ' <a href="" target="_blank">' . __( 'Click here to track your shipment', 'wc_shipment_tracking' ) . '</a></p>';
+	// Live preview.
+	echo '<p class="preview_tracking_link" style="display:none;">' . esc_attr__( 'Preview:', 'wc-vendors' ) . ' <a href="" target="_blank">' . __( 'Click here to track your shipment', 'wc-vendors' ) . '</a></p>';
 
 	?>
 
 
-	<input type="hidden" name="product_id" value="<?php echo $product_id; ?>">
-	<input type="hidden" name="order_id" value="<?php echo $order_id; ?>">
+	<input type="hidden" name="product_id" value="<?php echo esc_attr( $product_id ); ?>">
+	<input type="hidden" name="order_id" value="<?php echo esc_attr( $order_id ); ?>">
 
 	<input class="button" type="submit" name="update_tracking"
-	       value="<?php _e( 'Update tracking number', 'wc-vendors' ); ?>">
+		value="<?php esc_attr_e( 'Update tracking number', 'wc-vendors' ); ?>">
 	<input class="button" type="submit" name="mark_shipped"
-	       value="<?php _e( 'Mark as shipped', 'wc-vendors' ); ?>">
+		value="<?php esc_attr_e( 'Mark as shipped', 'wc-vendors' ); ?>">
 
 </form>


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Use gmdate() to avoid runtime errors associated with date() function.

Closes #625 

### How to test the changes in this Pull Request:

1. Go to Settings > General - change the timezone to somewhere other than the server time.
2. Process order and complete it.
3. Check that the order time in WC Vendors > commission
4. The commission date must be the same as the WooCommerce order date

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
