### PR TITLE
Fixed: Front-end issues of Store Info option 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,10 @@
 Changelog for WC Vendors Marketplace
+
 Version 2.1.19 - 11th March 2020
 
 * Confirm WordPress 5.4 and WooCommerce 4.0
 
-Version 2.1.18 - 5th February 2020 
+Version 2.1.18 - 5th February 2020
 
 * Added: New action hook to image field. (#620)
 * Updated: Vendor_list shortcode argument to has_products #595

--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -11,7 +11,7 @@
  * Requires at least:    5.0.0
  * Tested up to:         5.4
  * WC requires at least: 3.8.0
- * WC tested up to:      4.0
+ * WC tested up to:      4.0.1
  *
  * Text Domain:          wc-vendors
  * Domain Path:          /languages/
@@ -97,7 +97,7 @@ if ( wcv_is_woocommerce_activated() ) {
 	 */
 	class WC_Vendors {
 
-		public $version = '2.1.18';
+		public $version = '2.1.19';
 
 		/**
 		 * @var

--- a/classes/front/class-vendor-shop.php
+++ b/classes/front/class-vendor-shop.php
@@ -18,7 +18,6 @@ class WCV_Vendor_Shop {
 	function __construct() {
 
 		add_action( 'woocommerce_product_query', array( $this, 'vendor_shop_query' ), 10, 2 );
-		// add_filter( 'init', array( $this, 'add_rewrite_rules' ), 0 );
 		add_action( 'woocommerce_before_main_content', array( 'WCV_Vendor_Shop', 'shop_description' ), 30 );
 		add_filter( 'woocommerce_product_tabs', array( 'WCV_Vendor_Shop', 'seller_info_tab' ) );
 		add_filter( 'post_type_archive_link', array( 'WCV_Vendor_Shop', 'change_archive_link' ) );
@@ -106,6 +105,10 @@ class WCV_Vendor_Shop {
 	public static function seller_info_tab( $tabs ) {
 
 		global $post;
+
+		if ( ! wc_string_to_bool( get_option( 'wcvendors_label_store_info_enable', 'no' ) ) ){
+			return $tabs;
+		}
 
 		if ( WCV_Vendors::is_vendor( $post->post_author ) ) {
 


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #599.

### How to test the changes in this Pull Request:

1. Go to WCVendor settings > display ( Tab ) > Labels > Store Info
2.Check the box see store info tab shows on single product page
3. uncheck the box see store info tab no longer shows on single product page. 
