### PR TITLE
Fixed: Performance Issue: Vendor drop down on commissions page #656

### DIFF
--- a/classes/admin/class-wcv-commissions-page.php
+++ b/classes/admin/class-wcv-commissions-page.php
@@ -352,17 +352,16 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 	 */
 	public function vendor_dropdown( $post_type ) {
 
-		$user_args        = array( 'fields' => array( 'ID', 'display_name' ) );
-		$vendor_id        = isset( $_GET['vendor_id'] ) ? sanitize_text_field( wp_unslash( $_GET['vendor_id'] ) ) : '';
-		$new_args         = $user_args;
-		$new_args['role'] = 'vendor';
-		$users            = get_users( $new_args );
+		$selectbox_args = array(
+			'id'          => 'vendor_id',
+			'placeholder' => sprintf( __( 'Filer by %s', 'wc-vendors' ), wcv_get_vendor_name() ),
+		);
 
-		// Generate the drop down.
-		$output = '<select style="width:250px;" name="vendor_id" id="vendor_id" class="wc-enhanced-select">';
-		$output .= '<option></option>';
-		$output .= wcv_vendor_drop_down_options( $users, $vendor_id );
-		$output .= '</select>';
+		if ( isset( $_GET['vendor_id'] ) ) {
+			$selectbox_args['selected'] = sanitize_text_field( wp_unslash( $_GET['vendor_id'] ) );
+		}
+
+		$output = WCV_Product_Meta::vendor_selectbox( $selectbox_args, false );
 
 		echo $output; // phpcs:ignore
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Update the vendor dropdown list in WC Vendors > Commissions page to use the ajax search for vendors.

Closes #656  .

### How to test the changes in this Pull Request:

1. Go to WC Vendors > Commissions page
2. Click on the Filter by Vendor dropdown, you should see a searchbox with instruction to type a few characters to search.
3. Type to search for a vendor. Check the dropdown list is updated with vendors matching your search characters
4. Select a vendor and click 'Filter', after page load, the commissions listed should only be those matching the selected vendor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
