### PR TITLE
Fixed: Vendor assignment in product edit only recognizes vendors #661

### DIFF
--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -492,7 +492,7 @@ class WCV_Product_Meta {
 	  FROM  $wpdb->users
 		INNER JOIN $wpdb->usermeta as mt1 ON $wpdb->users.ID = mt1.user_id
 		INNER JOIN $wpdb->usermeta as mt2 ON $wpdb->users.ID = mt2.user_id
-	  WHERE ( mt1.meta_key = '$wpdb->prefix" . "capabilities' AND mt1.meta_value LIKE '%vendor%' )
+	  WHERE ( mt1.meta_key = '$wpdb->prefix" . "capabilities' AND ( mt1.meta_value LIKE '%vendor%' OR mt1.meta_value LIKE '%administrator%' ) )
 	  AND (
 		user_login LIKE $search_string
 		OR user_nicename LIKE $search_string


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #661 .

### How to test the changes in this Pull Request:

1. Assigned some of my admin products to a shop under WooCommerce-Products and save or update that product. 
2. Again open that product.
2. Now try to change them back to admin own products.