### PR TITLE
Fixed: "Commissions" page in the admin panel, page pagination does not work. #660

### DIFF
--- a/classes/admin/class-admin-menus.php
+++ b/classes/admin/class-admin-menus.php
@@ -28,7 +28,7 @@ class WCVendors_Admin_Menus {
 		add_action( 'admin_head', array( $this, 'commission_table_header_styles' ) );
 		add_action( 'admin_footer', array( $this, 'commission_table_script' ) );
 
-		add_filter( 'set-screen-option', array( __CLASS__, 'set_commissions_screen' ), 10, 3 );
+		add_filter( 'set_screen_option_wcvendor_commissions_perpage', array( __CLASS__, 'set_commissions_screen' ), 10, 3 );
 
 	}
 
@@ -178,7 +178,7 @@ class WCVendors_Admin_Menus {
 		$args   = [
 			'label'   => 'Commissions',
 			'default' => 10,
-			'option'  => 'commissions_per_page',
+			'option'  => 'wcvendor_commissions_perpage',
 		];
 
 		add_screen_option( $option, $args );

--- a/classes/admin/class-wcv-commissions-page.php
+++ b/classes/admin/class-wcv-commissions-page.php
@@ -490,7 +490,7 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 		$http_referer           = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		$_SERVER['REQUEST_URI'] = remove_query_arg( '_wp_http_referer', $http_referer );
 
-		$per_page     = $this->get_items_per_page( 'commissions_per_page', 10 );
+		$per_page     = $this->get_items_per_page( 'wcvendor_commissions_perpage', 10 );
 		$current_page = $this->get_pagenum();
 
 		$orderby    = ! empty( $_REQUEST['orderby'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['orderby'] ) ) : 'time';


### PR DESCRIPTION


### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #660 .

### How to test the changes in this Pull Request:

1. Go to 'WordPress Dashboard > WC Vendors > Commissions'
2. Click on 'Screen Options' on the upper-right corner
3. Change pagination from 10 to any other.
4. Apply value will be shown in the Screen Option and the list will also get updated.