### PR TITLE
Fixed: Product and category search not working on WooCommerce > Products

### DIFF
--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -179,7 +179,7 @@ class WCV_Product_Meta {
 		$users = get_users( $user_args );
 
 		$output = "<select style='width:200px;' name='$id' id='$id' class='wcv-vendor-select $class'>\n";
-		$output .= "\t<option value='nochange'>$placeholder</option>\n";
+		$output .= "\t<option value=''>$placeholder</option>\n";
 		foreach ( (array) $users as $user ) {
 			$select = selected( $user->ID, $selected, false );
 			$output .= "<option value='$user->ID' $select>$user->display_name</option>";


### PR DESCRIPTION
This fixes the search for both categories and products. 

### All Submissions:

* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #678  .

### How to test the changes in this Pull Request:

1. Load fix, try to use category filter or product search
2. Show results
3.
