### PR TITLE
Fixed: Depreciated JS in WP 5.5 #680

### DIFF
--- a/assets/js/admin/wcv-vendor-select.js
+++ b/assets/js/admin/wcv-vendor-select.js
@@ -1,7 +1,9 @@
 (function ($) {
     var debouncedInit = debounce(initSelect2, 100);
 
-    $(document).on('ready', initSelect2);
+    $( 'document' ).ready( function () {
+        initSelect2();
+    });
     $('button.editinline').on('click', debouncedInit);
     $('#doaction').on('click', function () {
         if ($('#bulk-action-selector-top').val() === 'edit')


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


Closes #680 .

### How to test the changes in this Pull Request:

1. Update your WordPress to 5.5 and check for the latest jQuery.
2. Check the wp-admin.
3. This depreciation warning will not show up.
