### PR TITLE
Bulk editing products and adding tags would cause the assigned vendor store on those bulk edited products to disappear #687

### DIFF
--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -321,7 +321,7 @@ class WCV_Product_Meta {
 
 		if ( $product->is_type( 'simple' ) || $product->is_type( 'external' ) ) {
 
-			if ( isset( $_REQUEST['_vendor'] ) ) {
+			if ( isset( $_REQUEST['_vendor'] ) && '' !== $_REQUEST['vendor'] ) {
 				$vendor            = wc_clean( $_REQUEST['_vendor'] );
 				$post              = get_post( $product->get_id() );
 				$post->post_author = $vendor;
@@ -365,11 +365,11 @@ class WCV_Product_Meta {
 	*/
 	public function save_vendor_bulk_edit( $product ) {
 
-		if( ! isset( $_REQUEST['vendor'] ) || isset( $_REQUEST['vendor'] ) && 'nochange' === $_REQUEST['vendor'] ) {
+		if( ! isset( $_REQUEST['vendor'] ) || isset( $_REQUEST['vendor'] ) && '' !== $_REQUEST['vendor'] ) {
 			return;
 		}
 
-		if ( isset( $_REQUEST['vendor'] ) && $_REQUEST['vendor'] != 'nochange'  ) {
+		if ( isset( $_REQUEST['vendor'] ) && '' !== $_REQUEST['vendor'] ) {
 			$vendor            = wc_clean( $_REQUEST['vendor'] );
 			$update_vendor = array(
 				'ID'          => $product->get_id(),


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Avoid setting empty vendor if a vendor was not specified for the bulk edited products.

Closes #687 

### How to test the changes in this Pull Request:

1. Go to WordPress products dashboard
2. Bulk edit products and add a tag.
3. The edited products must still have the vendor displayed in the Vendor Store column

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
