### PR TITLE
Updated: Add a filter to handle customer email notification for the mark received shipping #691

### DIFF
--- a/classes/admin/emails/class-emails.php
+++ b/classes/admin/emails/class-emails.php
@@ -219,7 +219,8 @@ class WCV_Emails {
 	/**
 	 * Trigger the notify vendor shipped emails
 	 *
-	 * @since 2.0.0
+	 * @version 2.2.2
+	 * @since   2.0.0
 	 */
 	public function vendor_shipped( $order_id, $user_id, $order ) {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
@@ -227,8 +228,11 @@ class WCV_Emails {
 		}
 		// Notify the admin
 		WC()->mailer()->emails['WCVendors_Admin_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
+
 		// Notify the customer
-		WC()->mailer()->emails['WCVendors_Customer_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
+		if( 'yes' === apply_filters( 'wcvendors_customer_email_notification_shipped', 'yes' ) ) {
+			WC()->mailer()->emails['WCVendors_Customer_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
+		}
 	}
 
 	/**

--- a/classes/admin/emails/class-emails.php
+++ b/classes/admin/emails/class-emails.php
@@ -230,7 +230,7 @@ class WCV_Emails {
 		WC()->mailer()->emails['WCVendors_Admin_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
 
 		// Notify the customer
-		if( 'yes' === apply_filters( 'wcvendors_customer_email_notification_shipped', 'yes' ) ) {
+		if( apply_filters( 'wcvendors_vendor_shipped_customer_notification', true ) ) {
 			WC()->mailer()->emails['WCVendors_Customer_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #691 .

### How to test the changes in this Pull Request:

1. Log in as a vendor.
2. Mark shipped any of the orders.
3. It will fire email and you can handle that with this new filter. By default I've put is enabled.
