### PR TITLE
Fixed: Importing WooCommerce products via CSV file using the default WooCommerce importer does not work if the WC Vendors Marketplace is activated. #689

### DIFF
--- a/classes/admin/class-wcv-admin-import-export.php
+++ b/classes/admin/class-wcv-admin-import-export.php
@@ -165,7 +165,7 @@ class WCV_Admin_Import_Export {
 	public function is_product_author( $data ) {
 		$vendor_id = get_current_user_id();
 		
-		if ( isset( $data['vendor_id'] ) && $vendor_id == $data['vendor_id'] ) {
+		if ( ( isset( $data['vendor_id'] ) && $vendor_id == $data['vendor_id'] ) || is_admin() ) {
 			return true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #689  .

### How to test the changes in this Pull Request:

1. Go to the WP dashboard > Tools > Import > WooCommerce products (CSV) > Run installer.
2. Use a CSV file that contains the WooCommerce products.
3. Test file here - https://drive.google.com/file/d/17SKt2gijfeVxtxRoVg-x4Qg3InRz7gGY/view?usp=sharing
4. Run the importer.
5. See that the products get imported.