### PR TITLE
Added: Filter to the vendor select minimum input length #688

### DIFF
--- a/assets/js/admin/wcv-vendor-select.js
+++ b/assets/js/admin/wcv-vendor-select.js
@@ -18,7 +18,7 @@
         var $selectBox = $('.wcv-vendor-select:visible');
 
         $selectBox.select2({
-            minimumInputLength: 4,
+            minimumInputLength: wcv_vendors_select.minimum_input_length,
             ajax: {
                 url: ajaxurl,
                 type: 'POST',

--- a/assets/js/admin/wcv-vendor-select.js
+++ b/assets/js/admin/wcv-vendor-select.js
@@ -18,7 +18,7 @@
         var $selectBox = $('.wcv-vendor-select:visible');
 
         $selectBox.select2({
-            minimumInputLength: wcv_vendors_select.minimum_input_length,
+            minimumInputLength: wcv_vendor_select.minimum_input_length,
             ajax: {
                 url: ajaxurl,
                 type: 'POST',

--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -52,6 +52,13 @@ class WCV_Product_Meta {
 
 	public function enqueue_script() {
 		wp_enqueue_script('wcv-vendor-select', wcv_assets_url . 'js/admin/wcv-vendor-select.js', array( 'select2' ), WCV_VERSION, true );
+		wp_localize_script(
+			'wcv-vendor-select',
+			'wcv_vendor_select',
+			array(
+				'minimum_input_length' => apply_filters( 'wcvndors_vendor_select_minimum_input_length', 4 ),
+			)
+		);
 	}
 
 	/**

--- a/classes/admin/emails/class-emails.php
+++ b/classes/admin/emails/class-emails.php
@@ -219,7 +219,8 @@ class WCV_Emails {
 	/**
 	 * Trigger the notify vendor shipped emails
 	 *
-	 * @since 2.0.0
+	 * @version 2.2.2
+	 * @since   2.0.0
 	 */
 	public function vendor_shipped( $order_id, $user_id, $order ) {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
@@ -227,8 +228,11 @@ class WCV_Emails {
 		}
 		// Notify the admin
 		WC()->mailer()->emails['WCVendors_Admin_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
+
 		// Notify the customer
-		WC()->mailer()->emails['WCVendors_Customer_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
+		if( 'yes' === apply_filters( 'wcvendors_customer_email_notification_shipped', 'yes' ) ) {
+			WC()->mailer()->emails['WCVendors_Customer_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
+		}
 	}
 
 	/**

--- a/classes/admin/emails/class-emails.php
+++ b/classes/admin/emails/class-emails.php
@@ -230,7 +230,7 @@ class WCV_Emails {
 		WC()->mailer()->emails['WCVendors_Admin_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
 
 		// Notify the customer
-		if( 'yes' === apply_filters( 'wcvendors_customer_email_notification_shipped', 'yes' ) ) {
+		if( apply_filters( 'wcvendors_vendor_shipped_customer_notification', true ) ) {
 			WC()->mailer()->emails['WCVendors_Customer_Notify_Shipped']->trigger( $order->get_id(), $user_id, $order );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add filter to change the minimum input length in vendors select dropdown.

Closes #688 

### How to test the changes in this Pull Request:

1. Add the filter below to functions.php

```
add_filter( 'wcvndors_vendor_select_minimum_input_length', function( $input_length ) {
	$input_length = 2;
	return $input_length;
});
```

2. Got to the admin dashboard and edit a product.
3. In the Vendor meta box, you should be able to search with 2 characters or the ones set in the `$input_length` in the filter.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
