### PR TITLE
Updated: User store name or user id for vendor search in wp admin #669

### DIFF
--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -509,10 +509,12 @@ class WCV_Product_Meta {
 		OR ( mt2.meta_key = 'first_name' AND mt2.meta_value LIKE $search_string )
 		OR ( mt2.meta_key = 'last_name' AND mt2.meta_value LIKE $search_string )
 		OR ( mt2.meta_key = 'pv_shop_name' AND mt2.meta_value LIKE $search_string )
+		OR ( mt2.meta_key = 'pv_shop_slug' AND mt2.meta_value LIKE $search_string )
+		OR ( mt2.meta_key = 'pv_seller_info' AND mt2.meta_value LIKE $search_string )
+		OR ( mt2.meta_key = 'pv_shop_description' AND mt2.meta_value LIKE $search_string )
 	  )
 	  ORDER BY display_name
 	";
-
 
 		$response = new stdClass();
 		$response->results = $wpdb->get_results( $sql );

--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -508,6 +508,7 @@ class WCV_Product_Meta {
 		OR user_url LIKE $search_string
 		OR ( mt2.meta_key = 'first_name' AND mt2.meta_value LIKE $search_string )
 		OR ( mt2.meta_key = 'last_name' AND mt2.meta_value LIKE $search_string )
+		OR ( mt2.meta_key = 'pv_shop_name' AND mt2.meta_value LIKE $search_string )
 	  )
 	  ORDER BY display_name
 	";
@@ -515,6 +516,7 @@ class WCV_Product_Meta {
 
 		$response = new stdClass();
 		$response->results = $wpdb->get_results( $sql );
+
 		wp_send_json($response);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Allow searching vendors by store name, store slug, store description and seller information.

Closes #669 

### How to test the changes in this Pull Request:

1. Got to admin and edit a product
2.  In the Author metabox, search for a vendor by store name, slug, description or seller info. 
3. You should get results matching your search in the vendor selectbox

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
