### PR TITLE
Fixed: Advanced option - Delete all data, requires the Wizard to be completed before users can use the shortcodes on the pages #681

### DIFF
--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -294,7 +294,9 @@ class WCV_Vendor_Dashboard {
 
 		do_action( 'wcvendors_before_dashboard' );
 
-		wc_print_notices();
+		if( function_exists ( 'wc_print_notices' ) ){ 
+			wc_print_notices();
+		}
 
 		wc_get_template(
 			'navigation.php',

--- a/templates/dashboard/links.php
+++ b/templates/dashboard/links.php
@@ -15,7 +15,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<?php wc_print_notices(); ?>
+<?php
+
+if( function_exists ( 'wc_print_notices' ) ){
+	wc_print_notices();
+}
+
+?>
 
 <center>
 	<p>


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #681 .

### How to test the changes in this Pull Request:

1. Use the advanced settings to delete data
2. Delete, reinstall, and reactivate plugins(marketplace and pro)
3. Without proceeding to the Setup wizard, try creating a page and use the shortcodes.