### PR TITLE
Deleted products don't have a title on the commissions table #702

### DIFF
--- a/classes/admin/class-wcv-commissions-page.php
+++ b/classes/admin/class-wcv-commissions-page.php
@@ -93,7 +93,17 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 					$product_id = WCV_Vendors::find_parent_id_from_order( $item->order_id, $product_id );
 				}
 
-				return '<a href="' . admin_url( 'post.php?post=' . $product_id . '&action=edit' ) . '">' . get_the_title( $product_id ) . '</a> (<span title="' . get_the_title( $product_id ) . ' has sold ' . $wcv_total_sales . ' times total.">' . $wcv_total_sales . '</span>)';
+				if( '' !== get_the_title( $product_id ) ) {
+					$product_url = '<a href="' . admin_url( 'post.php?post=' . $product_id . '&action=edit' ) . '">' . get_the_title( $product_id ) . '</a> (<span title="' . get_the_title( $product_id ) . ' has sold ' . $wcv_total_sales . ' times total.">' . $wcv_total_sales . '</span>)';
+				} else {
+					$order = wc_get_order( $item->order_id );
+					foreach ( $order->get_items() as $item_id => $items ) {
+						if( $product_id == $order->get_item_meta( $item_id, '_product_id', true) ) {
+							$product_url = $items->get_name();
+						}
+					}
+				}
+				return $product_url;
 			case 'order_id':
 				$order = wc_get_order( $item->order_id );
 				if ( $order ) {

--- a/classes/admin/class-wcv-commissions-page.php
+++ b/classes/admin/class-wcv-commissions-page.php
@@ -92,8 +92,7 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 				if ( ! get_post_status( $product_id ) ) {
 					$product_id = WCV_Vendors::find_parent_id_from_order( $item->order_id, $product_id );
 				}
-
-				if( '' !== get_the_title( $product_id ) ) {
+				if ( '' !== get_the_title( $product_id ) ) {
 					$product_url = '<a href="' . admin_url( 'post.php?post=' . $product_id . '&action=edit' ) . '">' . get_the_title( $product_id ) . '</a> (<span title="' . get_the_title( $product_id ) . ' has sold ' . $wcv_total_sales . ' times total.">' . $wcv_total_sales . '</span>)';
 				} else {
 					$order = wc_get_order( $item->order_id );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #702 .

### How to test the changes in this Pull Request:

1. Go to commissions and find a product that is listed. 
2. Delete the product permanently 
3. Check the commission's table, now you can see the product name without a link on it.