### PR TITLE
Updated: Remove deprecated payments tab from settings

### DIFF
--- a/classes/admin/settings/class-wcv-settings-payments.php
+++ b/classes/admin/settings/class-wcv-settings-payments.php
@@ -28,10 +28,13 @@ if ( ! class_exists( 'WCVendors_Settings_Payments', false ) ) :
 		 */
 		public function __construct() {
 
-			$this->id    = 'payments';
-			$this->label = __( 'Payments', 'wc-vendors' );
+			if ( $paypalap_settings && array_key_exists('username_live', $paypalap_settings ) && $paypalap_settings[ 'username_live' ] !== '' ) {
+				$this->id    = 'payments';
+				$this->label = __( 'Payments', 'wc-vendors' );
 
-			parent::__construct();
+				parent::__construct();	
+			}
+			
 		}
 
 

--- a/classes/admin/settings/class-wcv-settings-payments.php
+++ b/classes/admin/settings/class-wcv-settings-payments.php
@@ -28,6 +28,7 @@ if ( ! class_exists( 'WCVendors_Settings_Payments', false ) ) :
 		 */
 		public function __construct() {
 
+			$paypalap_settings = get_option( 'woocommerce_paypalap_settings', false );
 			if ( $paypalap_settings && array_key_exists('username_live', $paypalap_settings ) && $paypalap_settings[ 'username_live' ] !== '' ) {
 				$this->id    = 'payments';
 				$this->label = __( 'Payments', 'wc-vendors' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes the deprecated payments tab. 

Closes #704 .

### How to test the changes in this Pull Request:

1. Go to WC Vendors > Settings 
2. See payments tab is no longer available 

