### PR TITLE
Fixed: Yith Conflict - Add to wishlist button does not show up for vendor roles. #707

### DIFF
--- a/classes/admin/class-admin-users.php
+++ b/classes/admin/class-admin-users.php
@@ -65,7 +65,7 @@ class WCV_Admin_Users {
 			add_filter( 'manage_product_posts_columns', array( $this, 'manage_product_columns' ), 99 );
 
 			// Check allowed product types and hide controls
-			add_filter( 'product_type_options', array( $this, 'check_allowed_product_type_options' ) );
+			add_filter( 'product_type_options', array( $this, 'check_allowed_product_type_options' ) );			
 		}
 
 	}
@@ -157,28 +157,9 @@ class WCV_Admin_Users {
 	function filter_product_types( $types ) {
 
 		$product_types = (array) get_option( 'wcvendors_capability_product_types', array() );
-		$product_misc  = array(
-			'taxes'     => wc_string_to_bool( get_option( 'wcvendors_capability_product_taxes', 'no' ) ),
-			'sku'       => wc_string_to_bool( get_option( 'wcvendors_capability_product_sku', 'no' ) ),
-			'duplicate' => wc_string_to_bool( get_option( 'wcvendors_capability_product_duplicate', 'no' ) ),
-			'delete'    => wc_string_to_bool( get_option( 'wcvendors_capability_product_delete', 'no' ) ),
-			'featured'  => wc_string_to_bool( get_option( 'wcvendors_capability_product_featured', 'no' ) ),
-		);
+		$product_misc  = WCV_Product_Meta::get_product_capabilities();
 
-		// Add any custom css
-		$css = get_option( 'wcvendors_display_advanced_stylesheet' );
-		// Filter taxes
-		if ( ! empty( $product_misc['taxes'] ) ) {
-			$css .= '.form-field._tax_status_field, .form-field._tax_class_field{display:none !important;}';
-		}
 		unset( $product_misc['taxes'] );
-
-		// Filter the rest of the fields
-		foreach ( $product_misc as $key => $value ) {
-			if ( $value ) {
-				$css .= sprintf( '._%s_field{display:none !important;}', $key );
-			}
-		}
 
 		// Filter product type drop down
 		foreach ( $types as $key => $value ) {

--- a/classes/admin/class-admin-users.php
+++ b/classes/admin/class-admin-users.php
@@ -180,10 +180,6 @@ class WCV_Admin_Users {
 			}
 		}
 
-		echo '<style>';
-		echo $css;
-		echo '</style>';
-
 		// Filter product type drop down
 		foreach ( $types as $key => $value ) {
 			if ( in_array( $key, $product_types ) ) {

--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -44,7 +44,7 @@ class WCV_Vendor_Dashboard {
 			|| has_shortcode( $post->post_content, 'wcv_orders' )
 			|| has_shortcode( $post->post_content, 'wcv_vendor_dashboard_nav' )
 		) {
-			wp_enqueue_style( 'wcv_frontend_style', wcv_assets_url . 'css/wcv-frontend.css' );
+			wp_enqueue_style( 'wcv_frontend_style', wcv_assets_url . 'css/wcv-frontend.css' );			
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #707 .

### How to test the changes in this Pull Request:

1.  Log in as a customer/another role
2. Check a single product page and see the "Add to wishlist" Button
3. The 'Add to wishlist" button must be visible when logged in as Customer/Vendor/Administrator or any other role.
4. If the product is already on the wishlist, the appropriate message must be visible when logged in as Customer/Vendor/Administrator or any other role

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
