### PR TITLE
Fixed: Deprecated WooCommerce call #709

### DIFF
--- a/classes/admin/class-wcv-commissions-page.php
+++ b/classes/admin/class-wcv-commissions-page.php
@@ -97,7 +97,7 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 				} else {
 					$order = wc_get_order( $item->order_id );
 					foreach ( $order->get_items() as $item_id => $items ) {
-						if( $product_id == $order->get_item_meta( $item_id, '_product_id', true) ) {
+						if( $product_id == wc_get_order_item_meta( $item_id, '_product_id', true) ) {
 							$product_url = $items->get_name();
 						}
 					}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates code to remove deprecated call

Closes #709 

### How to test the changes in this Pull Request:

1. Ensure debugging is enabled
2. Delete a product that has had commission logged 
3. Check commissions table, no warnings. 

