### PR TITLE
Updated: Changed WooCommerce missing behaviour 

### DIFF
--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -39,16 +39,27 @@
 
 
 /**
+ * WooCommerce fallback notice.
+ *
+ * @since 2.2.2
+ */
+function wc_vendors_wc_missing_notice() {
+	/* translators: %s WooCommerce download URL link. */
+	echo '<div class="error"><p><strong>' . sprintf( esc_html__(  'WC Vendors Marketplace requires WooCommerce to run. You can download %s here.', 'wc-vendors' ), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
+}
+
+/**
  *   Plugin activation hook
  */
 function wcvendors_activate() {
 	/**
-	 *  Requires woocommerce to be installed and active
+	 *  Requires WooCommerce to be installed and active
 	 */
 	if ( ! class_exists( 'WooCommerce' ) ) {
-		deactivate_plugins( plugin_basename( __FILE__ ) );
-		wp_die( __( 'WC Vendors Marketplace requires WooCommerce to run. Please install WooCommerce and activate before attempting to activate again.', 'wc-vendors' ) );
+		add_action( 'admin_notices', 'wc_vendors_wc_missing_notice' );
+		return;
 	}
+
 	// Flush rewrite rules when activating plugin
 	flush_rewrite_rules();
 } // wcvendors_activate()
@@ -62,7 +73,6 @@ function wcvendors_deactivate() {
 }
 
 register_activation_hook( __FILE__, 'wcvendors_activate' );
-
 register_deactivation_hook( __FILE__, 'wcvendors_deactivate' );
 
 
@@ -450,4 +460,9 @@ if ( wcv_is_woocommerce_activated() ) {
 
 	$wc_vendors = new WC_Vendors();
 
+} else { 
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		add_action( 'admin_notices', 'wc_vendors_wc_missing_notice' );
+		return;
+	}
 }

--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -45,7 +45,7 @@
  */
 function wc_vendors_wc_missing_notice() {
 	/* translators: %s WooCommerce download URL link. */
-	echo '<div class="error"><p><strong>' . sprintf( esc_html__(  'WC Vendors Marketplace requires WooCommerce to run. You can download %s here.', 'wc-vendors' ), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
+	echo '<div class="error"><p><strong>' . sprintf( esc_html__(  'WC Vendors Marketplace requires WooCommerce to run. You can download %s here.', 'wc-vendors' ), '<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Instead of using the final wp_die to stop the plugin running, switch to a more graceful admin notice. 

Closes #711.

### How to test the changes in this Pull Request:

1. Activate WC Vendors Marketplace without WooCommerce activated
2. See the new admin notice
