### PR TITLE
Fixed: Bulk assigning products to a vendor does not work #724

### DIFF
--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -422,11 +422,11 @@ class WCV_Product_Meta {
 	*/
 	public function save_vendor_bulk_edit( $product ) {
 
-		if( ! isset( $_REQUEST['vendor'] ) || isset( $_REQUEST['vendor'] ) && '' !== $_REQUEST['vendor'] ) {
+		if( ! isset( $_REQUEST['vendor'] ) || isset( $_REQUEST['vendor'] ) && '' == $_REQUEST['vendor'] ) {
 			return;
 		}
 
-		if ( isset( $_REQUEST['vendor'] ) && '' !== $_REQUEST['vendor'] ) {
+		if ( isset( $_REQUEST['vendor'] ) && '' != $_REQUEST['vendor'] ) {
 			$vendor            = wc_clean( $_REQUEST['vendor'] );
 			$update_vendor = array(
 				'ID'          => $product->get_id(),


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixed the vendor ID condition check 

Closes #724 

### How to test the changes in this Pull Request:

1.  Go to Products > bulk select products and edit them.
2. From the vendor drop-down, select a vendor and then click update.
3. See that the bulk edited product's assigned vendor has changed to the newly assigned vendor.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
