### PR TITLE
Fixed: WC Vendors > Settings > Capabilities > General > Permissions > Vendor sales report table should get hidden as per permission set by admin. #756

### DIFF
--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -307,9 +307,9 @@ class WCV_Vendor_Dashboard {
 			wcv_plugin_dir . 'templates/dashboard/'
 		);
 
-		if ( $can_view_sales = get_option( 'wcvendors_capability_frontend_reports' ) ) {
+		if ( wc_string_to_bool( get_option( 'wcvendors_capability_frontend_reports', 'yes' ) ) ) {
 
-			$can_view_address = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_shipping' ) );
+			$can_view_address = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_shipping', 'yes' ) );
 
 			wc_get_template(
 				'reports.php',


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #756 .

### How to test the changes in this Pull Request:

1. Login as admin.
2. Click on to open WC Vendors > Settings > Capabilities > General tab.
3. Untick the check box with label as "Allow vendors to view sales table on the frontend on the vendors dashboard page."
4. Click on to save the settings.
5. Log in as Vendor(make sure that the vendor has some sales.)
6. Click on to open Vendor Dashboard.
7. Check for the sales table. Now, Sales table is not visible.