### PR TITLE
Updated: Action/Filter names need to be made consistent #716

### DIFF
--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -330,7 +330,8 @@ if ( wcv_is_woocommerce_activated() ) {
 					break;
 				case 'wc-vendors_page_wcv-commissions':
 					wp_register_script( 'wcv_admin_commissions', wcv_assets_url . 'js/admin/wcv-admin-commissions.js', array( 'jquery' ), WCV_VERSION , true );
-					$param_args = apply_filters( 'wcv_admin_commissions_params', array( 'confirm_prompt' => __( 'Are you sure you want mark all commissions paid?', 'wc-vendors' ) ) );
+					$param_args = apply_filters_deprecated( 'wcv_admin_commissions_params', array( array( 'confirm_prompt' => __( 'Are you sure you want mark all commissions paid?', 'wc-vendors' ) ) ), '3.0.0', 'wcvendors_admin_commissions_params' );
+					$param_args = apply_filters( 'wcvendors_admin_commissions_params', $param_args );
 					wp_localize_script( 'wcv_admin_commissions', 'wcv_admin_commissions_params', $param_args );
 					wp_enqueue_script( 'wcv_admin_commissions' );
 					break;

--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -330,7 +330,7 @@ if ( wcv_is_woocommerce_activated() ) {
 					break;
 				case 'wc-vendors_page_wcv-commissions':
 					wp_register_script( 'wcv_admin_commissions', wcv_assets_url . 'js/admin/wcv-admin-commissions.js', array( 'jquery' ), WCV_VERSION , true );
-					$param_args = apply_filters_deprecated( 'wcv_admin_commissions_params', array( array( 'confirm_prompt' => __( 'Are you sure you want mark all commissions paid?', 'wc-vendors' ) ) ), '3.0.0', 'wcvendors_admin_commissions_params' );
+					$param_args = apply_filters_deprecated( 'wcv_admin_commissions_params', array( array( 'confirm_prompt' => __( 'Are you sure you want mark all commissions paid?', 'wc-vendors' ) ) ), '2.3.0', 'wcvendors_admin_commissions_params' );
 					$param_args = apply_filters( 'wcvendors_admin_commissions_params', $param_args );
 					wp_localize_script( 'wcv_admin_commissions', 'wcv_admin_commissions_params', $param_args );
 					wp_enqueue_script( 'wcv_admin_commissions' );

--- a/classes/admin/class-admin-users.php
+++ b/classes/admin/class-admin-users.php
@@ -494,9 +494,9 @@ class WCV_Admin_Users {
 					$shop_name 		= WCV_Vendors::get_vendor_sold_by( $user_id  );
 					$display_name 	= empty( $shop_name ) ? get_the_author() : $shop_name;
 					$store_url 		= WCV_Vendors::get_vendor_shop_page( $user_id );
-					$target 		= apply_filters_deprecated( 'wcv_users_view_store_url_target', array( 'target="_blank"' ), '3.0.0', 'wcvendors_users_view_store_url_target' );
+					$target 		= apply_filters_deprecated( 'wcv_users_view_store_url_target', array( 'target="_blank"' ), '2.3.0', 'wcvendors_users_view_store_url_target' );
 					$target 		= apply_filters( 'wcvendors_users_view_store_url_target', $target );
-					$class 			= apply_filters_deprecated( 'wcv_users_view_store_url_class', array( 'class=""' ), '3.0.0', 'wcvendors_users_view_store_url_class' );
+					$class 			= apply_filters_deprecated( 'wcv_users_view_store_url_class', array( 'class=""' ), '2.3.0', 'wcvendors_users_view_store_url_class' );
 					$class 			= apply_filters( 'wcvendors_users_view_store_url_class', $class );
 					return sprintf(
 						'<a href="%s"%s%s>%s</a>',

--- a/classes/admin/class-admin-users.php
+++ b/classes/admin/class-admin-users.php
@@ -494,8 +494,10 @@ class WCV_Admin_Users {
 					$shop_name 		= WCV_Vendors::get_vendor_sold_by( $user_id  );
 					$display_name 	= empty( $shop_name ) ? get_the_author() : $shop_name;
 					$store_url 		= WCV_Vendors::get_vendor_shop_page( $user_id );
-					$target 		= apply_filters( 'wcv_users_view_store_url_target', 'target="_blank"' );
-					$class 			= apply_filters( 'wcv_users_view_store_url_class', 'class=""' );
+					$target 		= apply_filters_deprecated( 'wcv_users_view_store_url_target', array( 'target="_blank"' ), '3.0.0', 'wcvendors_users_view_store_url_target' );
+					$target 		= apply_filters( 'wcvendors_users_view_store_url_target', $target );
+					$class 			= apply_filters_deprecated( 'wcv_users_view_store_url_class', array( 'class=""' ), '3.0.0', 'wcvendors_users_view_store_url_class' );
+					$class 			= apply_filters( 'wcvendors_users_view_store_url_class', $class );
 					return sprintf(
 						'<a href="%s"%s%s>%s</a>',
 						$store_url,

--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -213,7 +213,8 @@ class WCV_Product_Meta {
 		 *
 		 * @param array $args The arguments to be filtered.
 		 */
-		$args = apply_filters( 'wcv_vendor_selectbox_args', $args );
+		$args = apply_filters_deprecated( 'wcv_vendor_selectbox_args', array( $args ), '3.0.0', 'wcvendors_vendor_selectbox_args' );
+		$args = apply_filters( 'wcvendors_vendor_selectbox_args', $args );
 
 		extract( $args );
 
@@ -232,7 +233,8 @@ class WCV_Product_Meta {
 		 *
 		 * @param array $user_args The arguments to be filtered.
 		 */
-		$user_args = apply_filters( 'wcv_vendor_selectbox_user_args',  $user_args );
+		$user_args = apply_filters_deprecated( 'wcv_vendor_selectbox_user_args',  array( $user_args ), '3.0.0', 'wcvendors_vendor_selectbox_user_args' );
+		$user_args = apply_filters( 'wcvendors_vendor_selectbox_user_args',  $user_args );
 		$users = get_users( $user_args );
 
 		$output = "<select style='width:200px;' name='$id' id='$id' class='wcv-vendor-select $class'>\n";
@@ -250,7 +252,8 @@ class WCV_Product_Meta {
 			$output .= '</label></p>';
         }
 
-		return apply_filters( 'wcv_vendor_selectbox', $output, $user_args, $media );
+		$output = apply_filters_deprecated( 'wcv_vendor_selectbox', array( $output, $user_args, $media ), '3.0.0', 'wcvendors_vendor_selectbox' );
+		return apply_filters( 'wcvendors_vendor_selectbox', $output, $user_args, $media );
 	}
 
 	/**

--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -30,7 +30,9 @@ class WCV_Product_Meta {
 		add_action( 'wp_dropdown_users', array( $this, 'author_vendor_roles' ), 0, 1 );
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_manage_posts' ), 12 );
 
-		if ( apply_filters( 'wcv_product_commission_tab', true ) ) {
+		$product_commission_tab = apply_filters_deprecated( 'wcv_product_commission_tab', array( true ), '3.0.0', 'wcvendors_product_commission_tab' );
+		$product_commission_tab = apply_filters( 'wcvendors_product_commission_tab', $product_commission_tab );
+		if ( $product_commission_tab ) {
 			add_action( 'woocommerce_product_write_panel_tabs', array( $this, 'add_tab' ) );
 			add_action( 'woocommerce_product_data_panels'     , array( $this, 'add_panel' ) );
 			add_action( 'woocommerce_process_product_meta'    , array( $this, 'save_panel' ) );

--- a/classes/admin/class-product-meta.php
+++ b/classes/admin/class-product-meta.php
@@ -30,7 +30,7 @@ class WCV_Product_Meta {
 		add_action( 'wp_dropdown_users', array( $this, 'author_vendor_roles' ), 0, 1 );
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_manage_posts' ), 12 );
 
-		$product_commission_tab = apply_filters_deprecated( 'wcv_product_commission_tab', array( true ), '3.0.0', 'wcvendors_product_commission_tab' );
+		$product_commission_tab = apply_filters_deprecated( 'wcv_product_commission_tab', array( true ), '2.3.0', 'wcvendors_product_commission_tab' );
 		$product_commission_tab = apply_filters( 'wcvendors_product_commission_tab', $product_commission_tab );
 		if ( $product_commission_tab ) {
 			add_action( 'woocommerce_product_write_panel_tabs', array( $this, 'add_tab' ) );
@@ -215,7 +215,7 @@ class WCV_Product_Meta {
 		 *
 		 * @param array $args The arguments to be filtered.
 		 */
-		$args = apply_filters_deprecated( 'wcv_vendor_selectbox_args', array( $args ), '3.0.0', 'wcvendors_vendor_selectbox_args' );
+		$args = apply_filters_deprecated( 'wcv_vendor_selectbox_args', array( $args ), '2.3.0', 'wcvendors_vendor_selectbox_args' );
 		$args = apply_filters( 'wcvendors_vendor_selectbox_args', $args );
 
 		extract( $args );
@@ -235,7 +235,7 @@ class WCV_Product_Meta {
 		 *
 		 * @param array $user_args The arguments to be filtered.
 		 */
-		$user_args = apply_filters_deprecated( 'wcv_vendor_selectbox_user_args',  array( $user_args ), '3.0.0', 'wcvendors_vendor_selectbox_user_args' );
+		$user_args = apply_filters_deprecated( 'wcv_vendor_selectbox_user_args',  array( $user_args ), '2.3.0', 'wcvendors_vendor_selectbox_user_args' );
 		$user_args = apply_filters( 'wcvendors_vendor_selectbox_user_args',  $user_args );
 		$users = get_users( $user_args );
 
@@ -254,7 +254,7 @@ class WCV_Product_Meta {
 			$output .= '</label></p>';
         }
 
-		$output = apply_filters_deprecated( 'wcv_vendor_selectbox', array( $output, $user_args, $media ), '3.0.0', 'wcvendors_vendor_selectbox' );
+		$output = apply_filters_deprecated( 'wcv_vendor_selectbox', array( $output, $user_args, $media ), '2.3.0', 'wcvendors_vendor_selectbox' );
 		return apply_filters( 'wcvendors_vendor_selectbox', $output, $user_args, $media );
 	}
 

--- a/classes/admin/class-setup-wizard.php
+++ b/classes/admin/class-setup-wizard.php
@@ -43,7 +43,9 @@ class WCVendors_Admin_Setup_Wizard {
 	 */
 	public function __construct() {
 
-		if ( apply_filters( 'wcv_enable_setup_wizard', true ) && current_user_can( 'manage_woocommerce' ) ) {
+		$enable_setup_wizard = apply_filters_deprecated( 'wcv_enable_setup_wizard', array( true ), '3.0.0', 'wcvendors_enable_setup_wizard' );
+		$enable_setup_wizard = apply_filters( 'wcvendors_enable_setup_wizard', $enable_setup_wizard );
+		if ( $enable_setup_wizard && current_user_can( 'manage_woocommerce' ) ) {
 			add_action( 'admin_menu', array( $this, 'admin_menus' ) );
 			add_action( 'admin_init', array( $this, 'setup_wizard' ) );
 			add_action( 'admin_head', array( $this, 'hide_setup_wizard' ) );

--- a/classes/admin/class-setup-wizard.php
+++ b/classes/admin/class-setup-wizard.php
@@ -97,7 +97,8 @@ class WCVendors_Admin_Setup_Wizard {
 			),
 		);
 
-		$this->steps = apply_filters( 'wcv_setup_wizard_steps', $default_steps );
+		$this->steps = apply_filters_deprecated( 'wcv_setup_wizard_steps', array( $default_steps ), '3.0.0', 'wcvendors_setup_wizard_steps' );
+		$this->steps = apply_filters( 'wcvendors_setup_wizard_steps', $this->steps );
 		$this->step  = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : current( array_keys( $this->steps ) );
 		$suffix      = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 

--- a/classes/admin/class-setup-wizard.php
+++ b/classes/admin/class-setup-wizard.php
@@ -43,7 +43,7 @@ class WCVendors_Admin_Setup_Wizard {
 	 */
 	public function __construct() {
 
-		$enable_setup_wizard = apply_filters_deprecated( 'wcv_enable_setup_wizard', array( true ), '3.0.0', 'wcvendors_enable_setup_wizard' );
+		$enable_setup_wizard = apply_filters_deprecated( 'wcv_enable_setup_wizard', array( true ), '2.3.0', 'wcvendors_enable_setup_wizard' );
 		$enable_setup_wizard = apply_filters( 'wcvendors_enable_setup_wizard', $enable_setup_wizard );
 		if ( $enable_setup_wizard && current_user_can( 'manage_woocommerce' ) ) {
 			add_action( 'admin_menu', array( $this, 'admin_menus' ) );
@@ -99,7 +99,7 @@ class WCVendors_Admin_Setup_Wizard {
 			),
 		);
 
-		$this->steps = apply_filters_deprecated( 'wcv_setup_wizard_steps', array( $default_steps ), '3.0.0', 'wcvendors_setup_wizard_steps' );
+		$this->steps = apply_filters_deprecated( 'wcv_setup_wizard_steps', array( $default_steps ), '2.3.0', 'wcvendors_setup_wizard_steps' );
 		$this->steps = apply_filters( 'wcvendors_setup_wizard_steps', $this->steps );
 		$this->step  = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : current( array_keys( $this->steps ) );
 		$suffix      = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';

--- a/classes/admin/class-wcv-admin-import-export.php
+++ b/classes/admin/class-wcv-admin-import-export.php
@@ -70,7 +70,8 @@ class WCV_Admin_Import_Export {
 		// column slug => column name
 		$options['vendor_id'] = __( 'Vendor ID', 'wc-vendors');
 
-		return apply_filters( 'wcv_csv_product_import_mapping_options', $options );
+		$options =  apply_filters_deprecated( 'wcv_csv_product_import_mapping_options', array( $options ), '3.0.0', 'wcvendors_csv_product_import_mapping_options' );
+		return apply_filters( 'wcvendors_csv_product_import_mapping_options', $options );
 	}
 
 	/**

--- a/classes/admin/class-wcv-admin-import-export.php
+++ b/classes/admin/class-wcv-admin-import-export.php
@@ -70,7 +70,7 @@ class WCV_Admin_Import_Export {
 		// column slug => column name
 		$options['vendor_id'] = __( 'Vendor ID', 'wc-vendors');
 
-		$options =  apply_filters_deprecated( 'wcv_csv_product_import_mapping_options', array( $options ), '3.0.0', 'wcvendors_csv_product_import_mapping_options' );
+		$options =  apply_filters_deprecated( 'wcv_csv_product_import_mapping_options', array( $options ), '2.3.0', 'wcvendors_csv_product_import_mapping_options' );
 		return apply_filters( 'wcvendors_csv_product_import_mapping_options', $options );
 	}
 

--- a/classes/admin/class-wcv-commissions-csv-exporter.php
+++ b/classes/admin/class-wcv-commissions-csv-exporter.php
@@ -195,7 +195,7 @@ class WCV_Commissions_CSV_Export extends WC_CSV_Exporter {
 				$row[ $column_id ] = $value;
 			}
 
-			$row = apply_filters_deprecated( 'wcv_commissions_export_row_data', array( $row, $commission ), '3.0.0', 'wcvendors_commissions_export_row_data' );
+			$row = apply_filters_deprecated( 'wcv_commissions_export_row_data', array( $row, $commission ), '2.3.0', 'wcvendors_commissions_export_row_data' );
 			$this->row_data[] = apply_filters( 'wcvendors_commissions_export_row_data', $row, $commission );
 		}
 

--- a/classes/admin/class-wcv-commissions-csv-exporter.php
+++ b/classes/admin/class-wcv-commissions-csv-exporter.php
@@ -195,7 +195,8 @@ class WCV_Commissions_CSV_Export extends WC_CSV_Exporter {
 				$row[ $column_id ] = $value;
 			}
 
-			$this->row_data[] = apply_filters( 'wcv_commissions_export_row_data', $row, $commission );
+			$row = apply_filters_deprecated( 'wcv_commissions_export_row_data', array( $row, $commission ), '3.0.0', 'wcvendors_commissions_export_row_data' );
+			$this->row_data[] = apply_filters( 'wcvendors_commissions_export_row_data', $row, $commission );
 		}
 
 	}

--- a/classes/admin/class-wcv-commissions-page.php
+++ b/classes/admin/class-wcv-commissions-page.php
@@ -228,7 +228,8 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 			// 'delete' 		=> __( 'Delete', 'wc-vendors'),
 		);
 
-		return apply_filters( 'wcv_edit_bulk_actions', $actions, '2.2.2', 'wcvendors_edit_bulk_actions' );
+		$actions = apply_filters_deprecated( 'wcv_edit_bulk_actions', array( $actions, '2.2.2', 'wcvendors_edit_bulk_actions' ), '3.0.0', 'wcvendors_edit_bulk_actions' );
+		return apply_filters( 'wcvendors_edit_bulk_actions', $actions, '2.2.2', 'wcvendors_edit_bulk_actions' );
 	}
 
 
@@ -614,6 +615,7 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 			'vendor_id'    => $vendor_id,
 		);
 		$sql = apply_filters_deprecated( 'wcv_get_commissions_sql', array( $sql, $sql_args ), '2.2.2', 'wcvendors_get_commissions_sql' );
+		$sql = apply_filters( 'wcvendors_get_commissions_sql', $sql, $sql_args );
 
 		$this->items = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 

--- a/classes/admin/class-wcv-commissions-page.php
+++ b/classes/admin/class-wcv-commissions-page.php
@@ -228,7 +228,7 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 			// 'delete' 		=> __( 'Delete', 'wc-vendors'),
 		);
 
-		$actions = apply_filters_deprecated( 'wcv_edit_bulk_actions', array( $actions, '2.2.2', 'wcvendors_edit_bulk_actions' ), '3.0.0', 'wcvendors_edit_bulk_actions' );
+		$actions = apply_filters_deprecated( 'wcv_edit_bulk_actions', array( $actions, '2.2.2', 'wcvendors_edit_bulk_actions' ), '2.3.0', 'wcvendors_edit_bulk_actions' );
 		return apply_filters( 'wcvendors_edit_bulk_actions', $actions, '2.2.2', 'wcvendors_edit_bulk_actions' );
 	}
 
@@ -431,7 +431,7 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 
 			default:
 				// code...
-				do_action_deprecated( 'wcv_edit_process_bulk_actions', array( $this->current_action(), $ids ), '3.0.0', 'wcvendors_edit_process_bulk_actions' );
+				do_action_deprecated( 'wcv_edit_process_bulk_actions', array( $this->current_action(), $ids ), '2.3.0', 'wcvendors_edit_process_bulk_actions' );
 				do_action( 'wcvendors_edit_process_bulk_actions', $this->current_action(), $ids );
 				break;
 		}

--- a/classes/admin/class-wcv-commissions-page.php
+++ b/classes/admin/class-wcv-commissions-page.php
@@ -431,7 +431,8 @@ class WCVendors_Commissions_Page extends WP_List_Table {
 
 			default:
 				// code...
-				do_action( 'wcv_edit_process_bulk_actions', $this->current_action(), $ids );
+				do_action_deprecated( 'wcv_edit_process_bulk_actions', array( $this->current_action(), $ids ), '3.0.0', 'wcvendors_edit_process_bulk_actions' );
+				do_action( 'wcvendors_edit_process_bulk_actions', $this->current_action(), $ids );
 				break;
 		}
 

--- a/classes/admin/class-wcv-commissions-sum-csv-exporter.php
+++ b/classes/admin/class-wcv-commissions-sum-csv-exporter.php
@@ -115,7 +115,8 @@ class WCV_Commissions_Sum_CSV_Export extends WC_CSV_Exporter {
 					$row[ $column_id ] = $value;
 				}
 
-				$this->row_data[] = apply_filters( 'wcv_sum_commissions_export_row_data', $row, $vendor_id, $total, $status );
+				$row = apply_filters_deprecated( 'wcv_sum_commissions_export_row_data', array( $row, $vendor_id, $total, $status ), '3.0.0', 'wcvendors_sum_commissions_export_row_data' );
+				$this->row_data[] = apply_filters( 'wcvendors_sum_commissions_export_row_data', $row, $vendor_id, $total, $status );
 			}
 		}
 

--- a/classes/admin/class-wcv-commissions-sum-csv-exporter.php
+++ b/classes/admin/class-wcv-commissions-sum-csv-exporter.php
@@ -115,7 +115,7 @@ class WCV_Commissions_Sum_CSV_Export extends WC_CSV_Exporter {
 					$row[ $column_id ] = $value;
 				}
 
-				$row = apply_filters_deprecated( 'wcv_sum_commissions_export_row_data', array( $row, $vendor_id, $total, $status ), '3.0.0', 'wcvendors_sum_commissions_export_row_data' );
+				$row = apply_filters_deprecated( 'wcv_sum_commissions_export_row_data', array( $row, $vendor_id, $total, $status ), '2.3.0', 'wcvendors_sum_commissions_export_row_data' );
 				$this->row_data[] = apply_filters( 'wcvendors_sum_commissions_export_row_data', $row, $vendor_id, $total, $status );
 			}
 		}

--- a/classes/admin/emails/class-wc-notify-vendor.php
+++ b/classes/admin/emails/class-wc-notify-vendor.php
@@ -121,7 +121,7 @@ class WC_Email_Notify_Vendor extends WC_Email {
 	 */
 	function check_order_totals( $total_rows, $order ) {
 
-		$commission_label                 = apply_filters_deprecated( 'wcv_notify_vendor_commission_label', array( __( 'Commission Subtotal:', 'wc-vendors' ) ), '3.0.0', 'wcvendors_notify_vendor_commission_label');
+		$commission_label                 = apply_filters_deprecated( 'wcv_notify_vendor_commission_label', array( __( 'Commission Subtotal:', 'wc-vendors' ) ), '2.3.0', 'wcvendors_notify_vendor_commission_label');
 		$commission_label                 = apply_filters( 'wcvendors_notify_vendor_commission_label', $commission_label );
 		$return['cart_subtotal']          = $total_rows['cart_subtotal'];
 		$return['cart_subtotal']['label'] = $commission_label;
@@ -131,7 +131,7 @@ class WC_Email_Notify_Vendor extends WC_Email {
 				'label' => '',
 				'value' => '',
 			);
-			$return['tax_subtotal']['label'] = apply_filters_deprecated( 'wcv_notify_vendor_tax_label', array( __( 'Tax Subtotal:', 'wc-vendors' ) ), '3.0.0', 'wcvendors_notify_vendor_tax_label' );
+			$return['tax_subtotal']['label'] = apply_filters_deprecated( 'wcv_notify_vendor_tax_label', array( __( 'Tax Subtotal:', 'wc-vendors' ) ), '2.3.0', 'wcvendors_notify_vendor_tax_label' );
 			$return['tax_subtotal']['label'] = apply_filters( 'wcvendors_notify_vendor_tax_label', $return['tax_subtotal']['label'] );
 		}
 

--- a/classes/admin/emails/class-wc-notify-vendor.php
+++ b/classes/admin/emails/class-wc-notify-vendor.php
@@ -121,7 +121,8 @@ class WC_Email_Notify_Vendor extends WC_Email {
 	 */
 	function check_order_totals( $total_rows, $order ) {
 
-		$commission_label                 = apply_filters( 'wcv_notify_vendor_commission_label', __( 'Commission Subtotal:', 'wc-vendors' ) );
+		$commission_label                 = apply_filters_deprecated( 'wcv_notify_vendor_commission_label', array( __( 'Commission Subtotal:', 'wc-vendors' ) ), '3.0.0', 'wcvendors_notify_vendor_commission_label');
+		$commission_label                 = apply_filters( 'wcvendors_notify_vendor_commission_label', $commission_label );
 		$return['cart_subtotal']          = $total_rows['cart_subtotal'];
 		$return['cart_subtotal']['label'] = $commission_label;
 
@@ -130,7 +131,8 @@ class WC_Email_Notify_Vendor extends WC_Email {
 				'label' => '',
 				'value' => '',
 			);
-			$return['tax_subtotal']['label'] = apply_filters( 'wcv_notify_vendor_tax_label', __( 'Tax Subtotal:', 'wc-vendors' ) );
+			$return['tax_subtotal']['label'] = apply_filters_deprecated( 'wcv_notify_vendor_tax_label', array( __( 'Tax Subtotal:', 'wc-vendors' ) ), '3.0.0', 'wcvendors_notify_vendor_tax_label' );
+			$return['tax_subtotal']['label'] = apply_filters( 'wcvendors_notify_vendor_tax_label', $return['tax_subtotal']['label'] );
 		}
 
 		$dues = WCV_Vendors::get_vendor_dues_from_order( $order );

--- a/classes/admin/emails/class-wcv-vendor-notify-cancelled-order.php
+++ b/classes/admin/emails/class-wcv-vendor-notify-cancelled-order.php
@@ -128,7 +128,7 @@ if ( ! class_exists( 'WCVendors_Vendor_Notify_Cancelled_Order' ) ) :
 				'sent_to_vendor' => true,
 				'plain_text'     => false,
 				'email'          => $this,
-			), 'woocommerce', $this->template_base ), $this ), '3.0.0', 'wcvendors_vendor_notify_order_get_content_html' );
+			), 'woocommerce', $this->template_base ), $this ), '2.3.0', 'wcvendors_vendor_notify_order_get_content_html' );
 
 			return apply_filters( 'wcvendors_vendor_notify_order_get_content_html', wc_get_template_html( $this->template_html, array(
 				'order'          => $this->object,
@@ -162,7 +162,7 @@ if ( ! class_exists( 'WCVendors_Vendor_Notify_Cancelled_Order' ) ) :
 				'totals_display' => $this->totals_display,
 				'plain_text'     => true,
 				'email'          => $this,
-			), 'woocommerce', $this->template_base ), $this ), '3.0.0', 'wcvendors_vendor_notify_order_get_content_plain' );
+			), 'woocommerce', $this->template_base ), $this ), '2.3.0', 'wcvendors_vendor_notify_order_get_content_plain' );
 
 			return apply_filters( 'wcvendors_vendor_notify_order_get_content_plain', wc_get_template_html( $this->template_plain, array(
 				'order'          => $this->object,

--- a/classes/admin/emails/class-wcv-vendor-notify-cancelled-order.php
+++ b/classes/admin/emails/class-wcv-vendor-notify-cancelled-order.php
@@ -118,7 +118,19 @@ if ( ! class_exists( 'WCVendors_Vendor_Notify_Cancelled_Order' ) ) :
 		 */
 		public function get_content_html() {
 
-			return apply_filters( 'wcv_vendor_notify_order_get_content_html', wc_get_template_html( $this->template_html, array(
+			$this->template_html = apply_filters_deprecated( 'wcv_vendor_notify_order_get_content_html', array( wc_get_template_html( $this->template_html, array(
+				'order'          => $this->object,
+				'vendor_id'      => $this->vendor_id,
+				'vendor_items'   => $this->order_items,
+				'email_heading'  => $this->get_heading(),
+				'totals_display' => $this->totals_display,
+				'sent_to_admin'  => false,
+				'sent_to_vendor' => true,
+				'plain_text'     => false,
+				'email'          => $this,
+			), 'woocommerce', $this->template_base ), $this ), '3.0.0', 'wcvendors_vendor_notify_order_get_content_html' );
+
+			return apply_filters( 'wcvendors_vendor_notify_order_get_content_html', wc_get_template_html( $this->template_html, array(
 				'order'          => $this->object,
 				'vendor_id'      => $this->vendor_id,
 				'vendor_items'   => $this->order_items,
@@ -140,7 +152,19 @@ if ( ! class_exists( 'WCVendors_Vendor_Notify_Cancelled_Order' ) ) :
 		 */
 		public function get_content_plain() {
 
-			return apply_filters( 'wcv_vendor_notify_order_get_content_plain', wc_get_template_html( $this->template_plain, array(
+			$this->template_plain = apply_filters_deprecated( 'wcv_vendor_notify_order_get_content_plain', array( wc_get_template_html( $this->template_plain, array(
+				'order'          => $this->object,
+				'vendor_id'      => $this->vendor_id,
+				'vendor_items'   => $this->order_items,
+				'email_heading'  => $this->get_heading(),
+				'sent_to_admin'  => false,
+				'sent_to_vendor' => true,
+				'totals_display' => $this->totals_display,
+				'plain_text'     => true,
+				'email'          => $this,
+			), 'woocommerce', $this->template_base ), $this ), '3.0.0', 'wcvendors_vendor_notify_order_get_content_plain' );
+
+			return apply_filters( 'wcvendors_vendor_notify_order_get_content_plain', wc_get_template_html( $this->template_plain, array(
 				'order'          => $this->object,
 				'vendor_id'      => $this->vendor_id,
 				'vendor_items'   => $this->order_items,

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -328,7 +328,7 @@ class WCV_Commission {
 			$commission = $default_commission;
 		}
 
-		$commission = apply_filters_deprecated( 'wcv_commission_rate_percent', array( $commission, $product_id ), '3.0.0', 'wcvendors_commission_rate_percent' );
+		$commission = apply_filters_deprecated( 'wcv_commission_rate_percent', array( $commission, $product_id ), '2.3.0', 'wcvendors_commission_rate_percent' );
 		return apply_filters( 'wcvendors_commission_rate_percent', $commission, $product_id );
 	}
 
@@ -351,7 +351,7 @@ class WCV_Commission {
 		$commission      = $product_price * ( $commission_rate / 100 );
 		$commission      = round( $commission, 2 );
 
-		$commission = apply_filters_deprecated( 'wcv_commission_rate', array( $commission, $product_id, $product_price, $order, $qty, $item ), '3.0.0', 'wcvendors_commission_rate' );
+		$commission = apply_filters_deprecated( 'wcv_commission_rate', array( $commission, $product_id, $product_price, $order, $qty, $item ), '2.3.0', 'wcvendors_commission_rate' );
 		return apply_filters( 'wcvendors_commission_rate', $commission, $product_id, $product_price, $order, $qty, $item );
 	}
 
@@ -401,7 +401,7 @@ class WCV_Commission {
 			}
 		}
 
-		do_action_deprecated( 'wcv_commissions_inserted', array( $orders ), '3.0.0', 'wcvendors_commissions_inserted' );
+		do_action_deprecated( 'wcv_commissions_inserted', array( $orders ), '2.3.0', 'wcvendors_commissions_inserted' );
 		do_action( 'wcvendors_commissions_inserted', $orders );
 	}
 

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -328,7 +328,8 @@ class WCV_Commission {
 			$commission = $default_commission;
 		}
 
-		return apply_filters( 'wcv_commission_rate_percent', $commission, $product_id );
+		$commission = apply_filters_deprecated( 'wcv_commission_rate_percent', array( $commission, $product_id ), '3.0.0', 'wcvendors_commission_rate_percent' );
+		return apply_filters( 'wcvendors_commission_rate_percent', $commission, $product_id );
 	}
 
 
@@ -350,7 +351,8 @@ class WCV_Commission {
 		$commission      = $product_price * ( $commission_rate / 100 );
 		$commission      = round( $commission, 2 );
 
-		return apply_filters( 'wcv_commission_rate', $commission, $product_id, $product_price, $order, $qty, $item );
+		$commission = apply_filters_deprecated( 'wcv_commission_rate', array( $commission, $product_id, $product_price, $order, $qty, $item ), '3.0.0', 'wcvendors_commission_rate' );
+		return apply_filters( 'wcvendors_commission_rate', $commission, $product_id, $product_price, $order, $qty, $item );
 	}
 
 

--- a/classes/class-commission.php
+++ b/classes/class-commission.php
@@ -401,7 +401,8 @@ class WCV_Commission {
 			}
 		}
 
-		do_action( 'wcv_commissions_inserted', $orders );
+		do_action_deprecated( 'wcv_commissions_inserted', array( $orders ), '3.0.0', 'wcvendors_commissions_inserted' );
+		do_action( 'wcvendors_commissions_inserted', $orders );
 	}
 
 

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -614,7 +614,7 @@ class WCVendors_Install {
 			),
 		);
 
-		$capabilities = apply_filters_deprecated( 'wcv_get_vendor_caps', array( $capabilities ), '3.0.0', 'wcvendors_get_vendor_caps' );
+		$capabilities = apply_filters_deprecated( 'wcv_get_vendor_caps', array( $capabilities ), '2.3.0', 'wcvendors_get_vendor_caps' );
 		return apply_filters( 'wcvendors_get_vendor_caps', $capabilities );
 
 	}

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -614,7 +614,8 @@ class WCVendors_Install {
 			),
 		);
 
-		return apply_filters( 'wcv_get_vendor_caps', $capabilities );
+		$capabilities = apply_filters_deprecated( 'wcv_get_vendor_caps', array( $capabilities ), '3.0.0', 'wcvendors_get_vendor_caps' );
+		return apply_filters( 'wcvendors_get_vendor_caps', $capabilities );
 
 	}
 }

--- a/classes/class-vendors.php
+++ b/classes/class-vendors.php
@@ -237,7 +237,8 @@ class WCV_Vendors {
 
 		// Reset the array keys
 		// $receivers = array_values( $receiver );
-		return apply_filters( 'wcv_vendor_dues', $receiver, $order, $group );
+		$receiver = apply_filters_deprecated( 'wcv_vendor_dues', array( $receiver, $order, $group ), '3.0.0', 'wcvendors_vendor_dues' );
+		return apply_filters( 'wcvendors_vendor_dues', $receiver, $order, $group );
 	}
 
 

--- a/classes/class-vendors.php
+++ b/classes/class-vendors.php
@@ -237,7 +237,7 @@ class WCV_Vendors {
 
 		// Reset the array keys
 		// $receivers = array_values( $receiver );
-		$receiver = apply_filters_deprecated( 'wcv_vendor_dues', array( $receiver, $order, $group ), '3.0.0', 'wcvendors_vendor_dues' );
+		$receiver = apply_filters_deprecated( 'wcv_vendor_dues', array( $receiver, $order, $group ), '2.3.0', 'wcvendors_vendor_dues' );
 		return apply_filters( 'wcvendors_vendor_dues', $receiver, $order, $group );
 	}
 

--- a/classes/front/class-vendor-shop.php
+++ b/classes/front/class-vendor-shop.php
@@ -128,9 +128,11 @@ class WCV_Vendor_Shop {
 
 				$seller_info       = do_shortcode( $seller_info );
 				self::$seller_info = '<div class="pv_seller_info">';
-				self::$seller_info .= apply_filters( 'wcv_before_seller_info_tab', '' );
+				self::$seller_info .= apply_filters_deprecated( 'wcv_before_seller_info_tab', array( '' ), '3.0.0', 'wcvendors_before_seller_info_tab' );
+				self::$seller_info .= apply_filters( 'wcvendors_before_seller_info_tab', self::$seller_info );
 				self::$seller_info .= ( $global_html || $has_html ) ? wpautop( wptexturize( $seller_info ) ) : sanitize_text_field( $seller_info );
-				self::$seller_info .= apply_filters( 'wcv_after_seller_info_tab', '' );
+				self::$seller_info .= apply_filters_deprecated( 'wcv_after_seller_info_tab', array( '' ), '3.0.0', 'wcvendors_after_seller_info_tab' );
+				self::$seller_info .= apply_filters( 'wcvendors_after_seller_info_tab', self::$seller_info );
 				self::$seller_info .= '</div>';
 
 				$tabs['seller_info'] = array(

--- a/classes/front/class-vendor-shop.php
+++ b/classes/front/class-vendor-shop.php
@@ -266,7 +266,8 @@ class WCV_Vendor_Shop {
 			$vendor_email     = $vendor->user_email;
 			$vendor_login     = $vendor->user_login;
 
-			do_action( 'wcv_before_main_header', $vendor_id );
+			do_action_deprecated( 'wcv_before_main_header', array( $vendor_id ), '3.0.0', 'wcvendors_before_main_header' );
+			do_action( 'wcvendors_before_main_header', $vendor_id );
 
 			wc_get_template(
 				'vendor-main-header.php', array(
@@ -280,7 +281,8 @@ class WCV_Vendor_Shop {
 			), 'wc-vendors/front/', wcv_plugin_dir . 'templates/front/'
 			);
 
-			do_action( 'wcv_after_main_header', $vendor_id );
+			do_action_deprecated( 'wcv_after_main_header', array( $vendor_id ), '3.0.0', 'wcvendors_after_main_header' );
+			do_action( 'wcvendors_after_main_header', $vendor_id );
 
 		}
 	}
@@ -309,7 +311,8 @@ class WCV_Vendor_Shop {
 			$vendor_email     = $vendor->user_email;
 			$vendor_login     = $vendor->user_login;
 
-			do_action( 'wcv_before_mini_header', $vendor->ID );
+			do_action_deprecated( 'wcv_before_mini_header', array( $vendor->ID ), '3.0.0', 'wcvendors_before_mini_header' );
+			do_action( 'wcvendors_before_mini_header', $vendor->ID );
 
 			wc_get_template(
 				'vendor-mini-header.php', array(
@@ -325,7 +328,8 @@ class WCV_Vendor_Shop {
 			), 'wc-vendors/front/', wcv_plugin_dir . 'templates/front/'
 			);
 
-			do_action( 'wcv_after_mini_header', $vendor->ID );
+			do_action_deprecated( 'wcv_after_mini_header', array( $vendor->ID ), '3.0.0', 'wcvendors_after_mini_header' );
+			do_action( 'wcvendors_after_mini_header', $vendor->ID );
 
 		}
 	}

--- a/classes/front/class-vendor-shop.php
+++ b/classes/front/class-vendor-shop.php
@@ -128,10 +128,10 @@ class WCV_Vendor_Shop {
 
 				$seller_info       = do_shortcode( $seller_info );
 				self::$seller_info = '<div class="pv_seller_info">';
-				self::$seller_info .= apply_filters_deprecated( 'wcv_before_seller_info_tab', array( '' ), '3.0.0', 'wcvendors_before_seller_info_tab' );
+				self::$seller_info .= apply_filters_deprecated( 'wcv_before_seller_info_tab', array( '' ), '2.3.0', 'wcvendors_before_seller_info_tab' );
 				self::$seller_info .= apply_filters( 'wcvendors_before_seller_info_tab', self::$seller_info );
 				self::$seller_info .= ( $global_html || $has_html ) ? wpautop( wptexturize( $seller_info ) ) : sanitize_text_field( $seller_info );
-				self::$seller_info .= apply_filters_deprecated( 'wcv_after_seller_info_tab', array( '' ), '3.0.0', 'wcvendors_after_seller_info_tab' );
+				self::$seller_info .= apply_filters_deprecated( 'wcv_after_seller_info_tab', array( '' ), '2.3.0', 'wcvendors_after_seller_info_tab' );
 				self::$seller_info .= apply_filters( 'wcvendors_after_seller_info_tab', self::$seller_info );
 				self::$seller_info .= '</div>';
 
@@ -266,7 +266,7 @@ class WCV_Vendor_Shop {
 			$vendor_email     = $vendor->user_email;
 			$vendor_login     = $vendor->user_login;
 
-			do_action_deprecated( 'wcv_before_main_header', array( $vendor_id ), '3.0.0', 'wcvendors_before_main_header' );
+			do_action_deprecated( 'wcv_before_main_header', array( $vendor_id ), '2.3.0', 'wcvendors_before_main_header' );
 			do_action( 'wcvendors_before_main_header', $vendor_id );
 
 			wc_get_template(
@@ -281,7 +281,7 @@ class WCV_Vendor_Shop {
 			), 'wc-vendors/front/', wcv_plugin_dir . 'templates/front/'
 			);
 
-			do_action_deprecated( 'wcv_after_main_header', array( $vendor_id ), '3.0.0', 'wcvendors_after_main_header' );
+			do_action_deprecated( 'wcv_after_main_header', array( $vendor_id ), '2.3.0', 'wcvendors_after_main_header' );
 			do_action( 'wcvendors_after_main_header', $vendor_id );
 
 		}
@@ -311,7 +311,7 @@ class WCV_Vendor_Shop {
 			$vendor_email     = $vendor->user_email;
 			$vendor_login     = $vendor->user_login;
 
-			do_action_deprecated( 'wcv_before_mini_header', array( $vendor->ID ), '3.0.0', 'wcvendors_before_mini_header' );
+			do_action_deprecated( 'wcv_before_mini_header', array( $vendor->ID ), '2.3.0', 'wcvendors_before_mini_header' );
 			do_action( 'wcvendors_before_mini_header', $vendor->ID );
 
 			wc_get_template(
@@ -328,7 +328,7 @@ class WCV_Vendor_Shop {
 			), 'wc-vendors/front/', wcv_plugin_dir . 'templates/front/'
 			);
 
-			do_action_deprecated( 'wcv_after_mini_header', array( $vendor->ID ), '3.0.0', 'wcvendors_after_mini_header' );
+			do_action_deprecated( 'wcv_after_mini_header', array( $vendor->ID ), '2.3.0', 'wcvendors_after_mini_header' );
 			do_action( 'wcvendors_after_mini_header', $vendor->ID );
 
 		}

--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -382,7 +382,7 @@ class WCV_Vendor_Dashboard {
 			);
 		}
 
-		$items = apply_filters_deprecated( 'wcv_dashboard_nav_items', array( $items ), '3.0.0', 'wcvendors_dashboard_nav_items' );
+		$items = apply_filters_deprecated( 'wcv_dashboard_nav_items', array( $items ), '2.3.0', 'wcvendors_dashboard_nav_items' );
 		return apply_filters( 'wcvendors_dashboard_nav_items', $items );
 	}
 

--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -382,7 +382,8 @@ class WCV_Vendor_Dashboard {
 			);
 		}
 
-		return apply_filters( 'wcv_dashboard_nav_items', $items );
+		$items = apply_filters_deprecated( 'wcv_dashboard_nav_items', array( $items ), '3.0.0', 'wcvendors_dashboard_nav_items' );
+		return apply_filters( 'wcvendors_dashboard_nav_items', $items );
 	}
 
 	/**

--- a/classes/includes/class-functions.php
+++ b/classes/includes/class-functions.php
@@ -107,7 +107,8 @@ if ( !function_exists( 'wcv_vendor_drop_down_options' ) ){
 			$select = selected( $user->ID, $vendor_id, false );
 			$output .= "<option value='$user->ID' $select>$display_name</option>";
 		}
-		return apply_filters('wcv_vendor_drop_down_options', $output );
+		$output = apply_filters_deprecated( 'wcv_vendor_drop_down_options', array( $output ), '3.0.0', 'wcvendors_vendor_drop_down_options' );
+		return apply_filters( 'wcvendors_vendor_drop_down_options', $output );
 	}
 }
 

--- a/classes/includes/class-functions.php
+++ b/classes/includes/class-functions.php
@@ -42,7 +42,8 @@ function wcv_get_vendor_name( $singluar = true, $upper_case = true ) {
 	$vendor_label = $singluar ? __( $vendor_singular, 'wc-vendors' ) : __( $vendor_plural, 'wc-vendors' );
 	$vendor_label = $upper_case ? ucfirst( $vendor_label ) : lcfirst( $vendor_label );
 
-	return apply_filters( 'wcv_vendor_display_name', $vendor_label, $vendor_singular, $vendor_plural, $singluar, $upper_case );
+	$vendor_label = apply_filters_deprecated( 'wcv_vendor_display_name', array( $vendor_label, $vendor_singular, $vendor_plural, $singluar, $upper_case), '3.0.0', 'wcvendors_vendor_display_name' );
+	return apply_filters( 'wcvendors_vendor_display_name', $vendor_label, $vendor_singular, $vendor_plural, $singluar, $upper_case );
 
 }
 
@@ -86,7 +87,8 @@ function wcv_get_dashboard_nav_item_classes( $item_id ) {
 
 	$classes = array( 'button' );
 
-	$classes = apply_filters( 'wcv_dashboard_nav_item_classes', $classes, $item_id );
+	$classes = apply_filters_deprecated( 'wcv_dashboard_nav_item_classes', array( $classes, $item_id ), '3.0.0', 'wcvendors_dashboard_nav_item_classes' );
+	$classes = apply_filters( 'wcvendors_dashboard_nav_item_classes', $classes, $item_id );
 
 	return implode( ' ', array_map( 'sanitize_html_class', $classes ) );
 }

--- a/classes/includes/class-functions.php
+++ b/classes/includes/class-functions.php
@@ -42,7 +42,7 @@ function wcv_get_vendor_name( $singluar = true, $upper_case = true ) {
 	$vendor_label = $singluar ? __( $vendor_singular, 'wc-vendors' ) : __( $vendor_plural, 'wc-vendors' );
 	$vendor_label = $upper_case ? ucfirst( $vendor_label ) : lcfirst( $vendor_label );
 
-	$vendor_label = apply_filters_deprecated( 'wcv_vendor_display_name', array( $vendor_label, $vendor_singular, $vendor_plural, $singluar, $upper_case), '3.0.0', 'wcvendors_vendor_display_name' );
+	$vendor_label = apply_filters_deprecated( 'wcv_vendor_display_name', array( $vendor_label, $vendor_singular, $vendor_plural, $singluar, $upper_case), '2.3.0', 'wcvendors_vendor_display_name' );
 	return apply_filters( 'wcvendors_vendor_display_name', $vendor_label, $vendor_singular, $vendor_plural, $singluar, $upper_case );
 
 }
@@ -87,7 +87,7 @@ function wcv_get_dashboard_nav_item_classes( $item_id ) {
 
 	$classes = array( 'button' );
 
-	$classes = apply_filters_deprecated( 'wcv_dashboard_nav_item_classes', array( $classes, $item_id ), '3.0.0', 'wcvendors_dashboard_nav_item_classes' );
+	$classes = apply_filters_deprecated( 'wcv_dashboard_nav_item_classes', array( $classes, $item_id ), '2.3.0', 'wcvendors_dashboard_nav_item_classes' );
 	$classes = apply_filters( 'wcvendors_dashboard_nav_item_classes', $classes, $item_id );
 
 	return implode( ' ', array_map( 'sanitize_html_class', $classes ) );
@@ -109,7 +109,7 @@ if ( !function_exists( 'wcv_vendor_drop_down_options' ) ){
 			$select = selected( $user->ID, $vendor_id, false );
 			$output .= "<option value='$user->ID' $select>$display_name</option>";
 		}
-		$output = apply_filters_deprecated( 'wcv_vendor_drop_down_options', array( $output ), '3.0.0', 'wcvendors_vendor_drop_down_options' );
+		$output = apply_filters_deprecated( 'wcv_vendor_drop_down_options', array( $output ), '2.3.0', 'wcvendors_vendor_drop_down_options' );
 		return apply_filters( 'wcvendors_vendor_drop_down_options', $output );
 	}
 }

--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -87,7 +87,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '2.3.0', 'wcvendors_shortcode_products_query' );
 		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
@@ -174,7 +174,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '2.3.0', 'wcvendors_shortcode_products_query' );
 		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
@@ -254,7 +254,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '2.3.0', 'wcvendors_shortcode_products_query' );
 		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
@@ -332,7 +332,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '2.3.0', 'wcvendors_shortcode_products_query' );
 		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
@@ -405,7 +405,7 @@ class WCV_Shortcodes {
 
 		add_filter( 'posts_clauses', array( 'WC_Shortcodes', 'order_by_rating_post_clauses' ) );
 
-		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '2.3.0', 'wcvendors_shortcode_products_query' );
 		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		remove_filter( 'posts_clauses', array( 'WC_Shortcodes', 'order_by_rating_post_clauses' ) );
@@ -479,7 +479,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '2.3.0', 'wcvendors_shortcode_products_query' );
 		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
@@ -574,7 +574,7 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '2.3.0', 'wcvendors_shortcode_products_query' );
 		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;

--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -87,7 +87,8 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -173,7 +174,8 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -252,7 +254,8 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -329,7 +332,8 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -401,7 +405,8 @@ class WCV_Shortcodes {
 
 		add_filter( 'posts_clauses', array( 'WC_Shortcodes', 'order_by_rating_post_clauses' ) );
 
-		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		remove_filter( 'posts_clauses', array( 'WC_Shortcodes', 'order_by_rating_post_clauses' ) );
 
@@ -474,7 +479,8 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 
@@ -568,7 +574,8 @@ class WCV_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'wcv_shortcode_products_query', $args, $atts ) );
+		$args = apply_filters_deprecated( 'wcv_shortcode_products_query', array( $args, $atts ), '3.0.0', 'wcvendors_shortcode_products_query' );
+		$products = new WP_Query( apply_filters( 'wcvendors_shortcode_products_query', $args, $atts ) );
 
 		$woocommerce_loop['columns'] = $columns;
 

--- a/classes/includes/wcv-template-functions.php
+++ b/classes/includes/wcv-template-functions.php
@@ -219,7 +219,8 @@ if ( ! function_exists( 'wcv_get_sold_by_link' )  ){
 			? sprintf( '<a href="%s" %s>%s</a>', WCV_Vendors::get_vendor_shop_page( $vendor_id ), $class, WCV_Vendors::get_vendor_sold_by( $vendor_id ) )
 			: get_bloginfo( 'name' );
 
-		return apply_filters( 'wcv_sold_by_link', $sold_by, $vendor_id );
+		$sold_by = apply_filters_deprecated( 'wcv_sold_by_link', array( $sold_by, $vendor_id ), '3.0.0', 'wcvendors_sold_by_link' );
+		return apply_filters( 'wcvendors_sold_by_link', $sold_by, $vendor_id );
 
 	}
 }

--- a/classes/includes/wcv-template-functions.php
+++ b/classes/includes/wcv-template-functions.php
@@ -219,7 +219,7 @@ if ( ! function_exists( 'wcv_get_sold_by_link' )  ){
 			? sprintf( '<a href="%s" %s>%s</a>', WCV_Vendors::get_vendor_shop_page( $vendor_id ), $class, WCV_Vendors::get_vendor_sold_by( $vendor_id ) )
 			: get_bloginfo( 'name' );
 
-		$sold_by = apply_filters_deprecated( 'wcv_sold_by_link', array( $sold_by, $vendor_id ), '3.0.0', 'wcvendors_sold_by_link' );
+		$sold_by = apply_filters_deprecated( 'wcv_sold_by_link', array( $sold_by, $vendor_id ), '2.3.0', 'wcvendors_sold_by_link' );
 		return apply_filters( 'wcvendors_sold_by_link', $sold_by, $vendor_id );
 
 	}

--- a/templates/dashboard/orders.php
+++ b/templates/dashboard/orders.php
@@ -101,8 +101,11 @@ if ( function_exists( 'wc_print_notices' ) ) {
 				<td>
 					<?php
 					$sum    = WCV_Queries::sum_for_orders( array( $order_id ), array( 'vendor_id' => get_current_user_id() ) );
-					$total  = $sum[0]->line_total;
-					$totals += $total;
+					$total = 0;
+					if ( 0 < count( $sum ) ) {
+						$total  = $sum[0]->line_total;
+						$totals += $total;
+					}
 					echo wc_price( $total );
 					?>
 				</td>

--- a/templates/emails/plain/vendor-order-details.php
+++ b/templates/emails/plain/vendor-order-details.php
@@ -18,7 +18,8 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 /* translators: %s: Order ID. */
 echo wp_kses_post( wc_strtoupper( sprintf( __( 'Order number: %s', 'wc-vendors' ), $order->get_order_number() ) ) ) . "\n";
 echo wc_format_datetime( $order->get_date_created() ) . "\n";  // WPCS: XSS ok.
-do_action( 'wcv_email_vendor_notify_order_before_order_items' ) . "\n";
+do_action_deprecated( 'wcv_email_vendor_notify_order_before_order_items', array(), '3.0.0', 'wcvendors_email_vendor_notify_order_before_order_items' ) . "\n";
+do_action( 'wcvendors_email_vendor_notify_order_before_order_items' ) . "\n";
 echo "\n" . wcv_get_vendor_order_items(
 		$order, array( // WPCS: XSS ok.
 		               'show_sku'       => $sent_to_vendor,
@@ -32,7 +33,8 @@ echo "\n" . wcv_get_vendor_order_items(
 		               'sent_to_vendor' => $sent_to_vendor,
 		)
 	);
-do_action( 'wcv_email_vendor_notify_order_after_order_items' ) . "\n";
+do_action_deprecated( 'wcv_email_vendor_notify_order_after_order_items', array(), '3.0.0', 'wcvendors_email_vendor_notify_order_after_order_items' ) . "\n";
+do_action( 'wcvendors_email_vendor_notify_order_after_order_items' ) . "\n";
 
 echo "==========\n\n";
 
@@ -47,9 +49,11 @@ if ( $totals ) {
 }
 
 if ( $order->get_customer_note() ) {
-	do_action( 'wcv_vendor_notify_order_before_customer_note' ) . "\n";
+	do_action_deprecated( 'wcv_vendor_notify_order_before_customer_note', array(), '3.0.0', 'wcvendors_vendor_notify_order_before_customer_note' ) . "\n";
+	do_action( 'wcvendors_vendor_notify_order_before_customer_note' ) . "\n";
 	echo esc_html__( 'Note:', 'wc-vendors' ) . "\t " . wp_kses_post( wptexturize( $order->get_customer_note() ) ) . "\n";
-	do_action( 'wcv_vendor_notify_order_after_customer_note' ) . "\n";
+	do_action_deprecated( 'wcv_vendor_notify_order_after_customer_note', array(), '3.0.0', 'wcvendors_vendor_notify_order_after_customer_note' ) . "\n";
+	do_action( 'wcvendors_vendor_notify_order_after_customer_note' ) . "\n";
 }
 
 

--- a/templates/emails/plain/vendor-order-details.php
+++ b/templates/emails/plain/vendor-order-details.php
@@ -37,7 +37,8 @@ do_action( 'wcv_email_vendor_notify_order_after_order_items' ) . "\n";
 echo "==========\n\n";
 
 $totals = wcv_get_vendor_item_totals( $order, $vendor_items, $vendor_id, $email, $totals_display );
-$totals = apply_filters( 'wcv_vendor_notify_order_item_totals', $totals, $order, $vendor_items, $vendor_id, $email, $totals_display );
+$totals = apply_filters_deprecated( 'wcv_vendor_notify_order_item_totals', array( $totals, $order, $vendor_items, $vendor_id, $email, $totals_display ), '3.0.0', 'wcvendors_vendor_notify_order_item_totals' );
+$totals = apply_filters( 'wcvendors_vendor_notify_order_item_totals', $totals, $order, $vendor_items, $vendor_id, $email, $totals_display );
 
 if ( $totals ) {
 	foreach ( $totals as $total ) {

--- a/templates/emails/plain/vendor-order-details.php
+++ b/templates/emails/plain/vendor-order-details.php
@@ -18,7 +18,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 /* translators: %s: Order ID. */
 echo wp_kses_post( wc_strtoupper( sprintf( __( 'Order number: %s', 'wc-vendors' ), $order->get_order_number() ) ) ) . "\n";
 echo wc_format_datetime( $order->get_date_created() ) . "\n";  // WPCS: XSS ok.
-do_action_deprecated( 'wcv_email_vendor_notify_order_before_order_items', array(), '3.0.0', 'wcvendors_email_vendor_notify_order_before_order_items' ) . "\n";
+do_action_deprecated( 'wcv_email_vendor_notify_order_before_order_items', array(), '2.3.0', 'wcvendors_email_vendor_notify_order_before_order_items' ) . "\n";
 do_action( 'wcvendors_email_vendor_notify_order_before_order_items' ) . "\n";
 echo "\n" . wcv_get_vendor_order_items(
 		$order, array( // WPCS: XSS ok.
@@ -33,13 +33,13 @@ echo "\n" . wcv_get_vendor_order_items(
 		               'sent_to_vendor' => $sent_to_vendor,
 		)
 	);
-do_action_deprecated( 'wcv_email_vendor_notify_order_after_order_items', array(), '3.0.0', 'wcvendors_email_vendor_notify_order_after_order_items' ) . "\n";
+do_action_deprecated( 'wcv_email_vendor_notify_order_after_order_items', array(), '2.3.0', 'wcvendors_email_vendor_notify_order_after_order_items' ) . "\n";
 do_action( 'wcvendors_email_vendor_notify_order_after_order_items' ) . "\n";
 
 echo "==========\n\n";
 
 $totals = wcv_get_vendor_item_totals( $order, $vendor_items, $vendor_id, $email, $totals_display );
-$totals = apply_filters_deprecated( 'wcv_vendor_notify_order_item_totals', array( $totals, $order, $vendor_items, $vendor_id, $email, $totals_display ), '3.0.0', 'wcvendors_vendor_notify_order_item_totals' );
+$totals = apply_filters_deprecated( 'wcv_vendor_notify_order_item_totals', array( $totals, $order, $vendor_items, $vendor_id, $email, $totals_display ), '2.3.0', 'wcvendors_vendor_notify_order_item_totals' );
 $totals = apply_filters( 'wcvendors_vendor_notify_order_item_totals', $totals, $order, $vendor_items, $vendor_id, $email, $totals_display );
 
 if ( $totals ) {
@@ -49,10 +49,10 @@ if ( $totals ) {
 }
 
 if ( $order->get_customer_note() ) {
-	do_action_deprecated( 'wcv_vendor_notify_order_before_customer_note', array(), '3.0.0', 'wcvendors_vendor_notify_order_before_customer_note' ) . "\n";
+	do_action_deprecated( 'wcv_vendor_notify_order_before_customer_note', array(), '2.3.0', 'wcvendors_vendor_notify_order_before_customer_note' ) . "\n";
 	do_action( 'wcvendors_vendor_notify_order_before_customer_note' ) . "\n";
 	echo esc_html__( 'Note:', 'wc-vendors' ) . "\t " . wp_kses_post( wptexturize( $order->get_customer_note() ) ) . "\n";
-	do_action_deprecated( 'wcv_vendor_notify_order_after_customer_note', array(), '3.0.0', 'wcvendors_vendor_notify_order_after_customer_note' ) . "\n";
+	do_action_deprecated( 'wcv_vendor_notify_order_after_customer_note', array(), '2.3.0', 'wcvendors_vendor_notify_order_after_customer_note' ) . "\n";
 	do_action( 'wcvendors_vendor_notify_order_after_customer_note' ) . "\n";
 }
 

--- a/templates/emails/vendor-new-order.php
+++ b/templates/emails/vendor-new-order.php
@@ -38,7 +38,7 @@ $order_date         = $order->get_date_created();
 	</tr>
 	</thead>
 	<tbody>
-	<?php do_action_deprecated( 'wcv_before_vendor_new_order_items', array(), '3.0.0', 'wcvendors_before_vendor_new_order_items' ); ?>
+	<?php do_action_deprecated( 'wcv_before_vendor_new_order_items', array(), '2.3.0', 'wcvendors_before_vendor_new_order_items' ); ?>
 	<?php do_action( 'wcvendors_before_vendor_new_order_items' ); ?>
 	<?php
 	echo wc_get_email_order_items(
@@ -51,7 +51,7 @@ $order_date         = $order->get_date_created();
 		)
 	);
 	?>
-	<?php do_action_deprecated( 'wcv_after_vendor_new_order_items', array(), '3.0.0', 'wcvendors_after_vendor_new_order_items' ); ?>
+	<?php do_action_deprecated( 'wcv_after_vendor_new_order_items', array(), '2.3.0', 'wcvendors_after_vendor_new_order_items' ); ?>
 	<?php do_action( 'wcvendors_after_vendor_new_order_items' ); ?>
 	</tbody>
 	<tfoot>

--- a/templates/emails/vendor-new-order.php
+++ b/templates/emails/vendor-new-order.php
@@ -38,7 +38,8 @@ $order_date         = $order->get_date_created();
 	</tr>
 	</thead>
 	<tbody>
-	<?php do_action( 'wcv_after_vendor_new_order_items' ); ?>
+	<?php do_action_deprecated( 'wcv_before_vendor_new_order_items', array(), '3.0.0', 'wcvendors_before_vendor_new_order_items' ); ?>
+	<?php do_action( 'wcvendors_before_vendor_new_order_items' ); ?>
 	<?php
 	echo wc_get_email_order_items(
 		$order, array(
@@ -50,7 +51,8 @@ $order_date         = $order->get_date_created();
 		)
 	);
 	?>
-	<?php do_action( 'wcv_after_vendor_new_order_items' ); ?>
+	<?php do_action_deprecated( 'wcv_after_vendor_new_order_items', array(), '3.0.0', 'wcvendors_after_vendor_new_order_items' ); ?>
+	<?php do_action( 'wcvendors_after_vendor_new_order_items' ); ?>
 	</tbody>
 	<tfoot>
 	<?php

--- a/templates/emails/vendor-order-details.php
+++ b/templates/emails/vendor-order-details.php
@@ -50,7 +50,8 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		</tr>
 		</thead>
 		<tbody>
-		<?php do_action( 'wcv_email_vendor_notify_order_before_order_items', $order, $sent_to_admin, $plain_text, $email ); ?>
+		<?php do_action_deprecated( 'wcv_email_vendor_notify_order_before_order_items', array( $order, $sent_to_admin, $plain_text, $email ), '3.0.0', 'wcvendors_email_vendor_notify_order_before_order_items' ); ?>
+		<?php do_action( 'wcvendors_email_vendor_notify_order_before_order_items', $order, $sent_to_admin, $plain_text, $email ); ?>
 		<?php
 		echo wcv_get_vendor_order_items(
 			$order, array( // WPCS: XSS ok.
@@ -66,13 +67,15 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 			)
 		);
 		?>
-		<?php do_action( 'wcv_email_vendor_notify_order_after_order_items', $order, $sent_to_admin, $plain_text, $email ); ?>
+		<?php do_action_deprecated( 'wcv_email_vendor_notify_order_after_order_items', array( $order, $sent_to_admin, $plain_text, $email ), '3.0.0', 'wcvendors_email_vendor_notify_order_after_order_items' ); ?>
+		<?php do_action( 'wcvendors_email_vendor_notify_order_after_order_items', $order, $sent_to_admin, $plain_text, $email ); ?>
 		</tbody>
 		<tfoot>
 		<?php
 		$totals = wcv_get_vendor_item_totals( $order, $vendor_items, $vendor_id, $email, $totals_display );
 
-		do_action( 'wcv_before_vendor_item_totals', $order, $vendor_id, $email, $totals, $colspan, $text_align );
+		do_action_deprecated( 'wcv_before_vendor_item_totals', array( $order, $vendor_id, $email, $totals, $colspan, $text_align ), '3.0.0', 'wcvendors_before_vendor_item_totals' );
+		do_action( 'wcvendors_before_vendor_item_totals', $order, $vendor_id, $email, $totals, $colspan, $text_align );
 
 		if ( $totals ) {
 			$i = 0;
@@ -89,7 +92,8 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 			}
 		}
 
-		do_action( 'wcv_before_vendor_item_totals', $order, $vendor_id, $email, $totals, $colspan, $text_align );
+		do_action_deprecated( 'wcv_after_vendor_item_totals', array( $order, $vendor_id, $email, $totals, $colspan, $text_align ), '3.0.0', 'wcvendors_after_vendor_item_totals' );
+		do_action( 'wcvendors_after_vendor_item_totals', $order, $vendor_id, $email, $totals, $colspan, $text_align );
 
 		if ( $order->get_customer_note() ) {
 			?>
@@ -99,7 +103,8 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				<td class="td"
 				    style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php echo wp_kses_post( wptexturize( $order->get_customer_note() ) ); ?></td>
 			</tr>
-			<?php do_action( 'wcv_vendor_notify_order_after_customer_note', $order, $vendor_id, $email ); ?>
+			<?php do_action_deprecated( 'wcv_vendor_notify_order_after_customer_note', array( $order, $vendor_id, $email ), '3.0.0', 'wcvendors_vendor_notify_order_after_customer_note' ); ?>
+			<?php do_action( 'wcvendors_vendor_notify_order_after_customer_note', $order, $vendor_id, $email ); ?>
 			<?php
 		}
 		?>

--- a/templates/emails/vendor-order-details.php
+++ b/templates/emails/vendor-order-details.php
@@ -50,7 +50,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		</tr>
 		</thead>
 		<tbody>
-		<?php do_action_deprecated( 'wcv_email_vendor_notify_order_before_order_items', array( $order, $sent_to_admin, $plain_text, $email ), '3.0.0', 'wcvendors_email_vendor_notify_order_before_order_items' ); ?>
+		<?php do_action_deprecated( 'wcv_email_vendor_notify_order_before_order_items', array( $order, $sent_to_admin, $plain_text, $email ), '2.3.0', 'wcvendors_email_vendor_notify_order_before_order_items' ); ?>
 		<?php do_action( 'wcvendors_email_vendor_notify_order_before_order_items', $order, $sent_to_admin, $plain_text, $email ); ?>
 		<?php
 		echo wcv_get_vendor_order_items(
@@ -67,14 +67,14 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 			)
 		);
 		?>
-		<?php do_action_deprecated( 'wcv_email_vendor_notify_order_after_order_items', array( $order, $sent_to_admin, $plain_text, $email ), '3.0.0', 'wcvendors_email_vendor_notify_order_after_order_items' ); ?>
+		<?php do_action_deprecated( 'wcv_email_vendor_notify_order_after_order_items', array( $order, $sent_to_admin, $plain_text, $email ), '2.3.0', 'wcvendors_email_vendor_notify_order_after_order_items' ); ?>
 		<?php do_action( 'wcvendors_email_vendor_notify_order_after_order_items', $order, $sent_to_admin, $plain_text, $email ); ?>
 		</tbody>
 		<tfoot>
 		<?php
 		$totals = wcv_get_vendor_item_totals( $order, $vendor_items, $vendor_id, $email, $totals_display );
 
-		do_action_deprecated( 'wcv_before_vendor_item_totals', array( $order, $vendor_id, $email, $totals, $colspan, $text_align ), '3.0.0', 'wcvendors_before_vendor_item_totals' );
+		do_action_deprecated( 'wcv_before_vendor_item_totals', array( $order, $vendor_id, $email, $totals, $colspan, $text_align ), '2.3.0', 'wcvendors_before_vendor_item_totals' );
 		do_action( 'wcvendors_before_vendor_item_totals', $order, $vendor_id, $email, $totals, $colspan, $text_align );
 
 		if ( $totals ) {
@@ -92,7 +92,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 			}
 		}
 
-		do_action_deprecated( 'wcv_after_vendor_item_totals', array( $order, $vendor_id, $email, $totals, $colspan, $text_align ), '3.0.0', 'wcvendors_after_vendor_item_totals' );
+		do_action_deprecated( 'wcv_after_vendor_item_totals', array( $order, $vendor_id, $email, $totals, $colspan, $text_align ), '2.3.0', 'wcvendors_after_vendor_item_totals' );
 		do_action( 'wcvendors_after_vendor_item_totals', $order, $vendor_id, $email, $totals, $colspan, $text_align );
 
 		if ( $order->get_customer_note() ) {
@@ -103,7 +103,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				<td class="td"
 				    style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php echo wp_kses_post( wptexturize( $order->get_customer_note() ) ); ?></td>
 			</tr>
-			<?php do_action_deprecated( 'wcv_vendor_notify_order_after_customer_note', array( $order, $vendor_id, $email ), '3.0.0', 'wcvendors_vendor_notify_order_after_customer_note' ); ?>
+			<?php do_action_deprecated( 'wcv_vendor_notify_order_after_customer_note', array( $order, $vendor_id, $email ), '2.3.0', 'wcvendors_vendor_notify_order_after_customer_note' ); ?>
 			<?php do_action( 'wcvendors_vendor_notify_order_after_customer_note', $order, $vendor_id, $email ); ?>
 			<?php
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #716 .

### How to test the changes in this Pull Request:

1. Check all the filter and action hooks with the new prefixes.
2. Old filter and action will still work but that will give you **PHP Deprecated** warning.
