### PR TITLE
Updated: Disabled cron system if deprecated PayPal settings not active

### DIFF
--- a/classes/class-cron.php
+++ b/classes/class-cron.php
@@ -14,10 +14,15 @@ class WCV_Cron {
 	 */
 	function __construct() {
 
-		add_filter( 'cron_schedules'                  , array( 'WCV_Cron', 'custom_cron_intervals' ) );
-		add_action( 'wcvendors_settings_save_payments', array( 'WCV_Cron', 'check_schedule'        ) );
+		$settings = get_option( 'woocommerce_paypalap_settings', false );
+		if ( $settings && array_key_exists('username_live', $settings ) && $settings[ 'username_live' ] !== '' ) {
+			add_filter( 'cron_schedules'                  , array( 'WCV_Cron', 'custom_cron_intervals' ) );
+			add_action( 'wcvendors_settings_save_payments', array( 'WCV_Cron', 'check_schedule'        ) );
 
-		add_filter( 'wcvendors_admin_settings_sanitize_option_wcvendors_payments_paypal_schedule', array( 'WCV_Cron', 'check_schedule_now' ) );
+			add_filter( 'wcvendors_admin_settings_sanitize_option_wcvendors_payments_paypal_schedule', array( 'WCV_Cron', 'check_schedule_now' ) );
+		}
+
+		
 		// add_filter( WC_Vendors::$id . '_options_on_update', array( 'WCV_Cron', 'check_schedule_now' ) );
 	}
 

--- a/classes/class-cron.php
+++ b/classes/class-cron.php
@@ -3,6 +3,8 @@
  * Cron class
  *
  * @package WC_Vendors
+ * @deprecated 1.9 
+ * 
  */
 
 
@@ -18,12 +20,9 @@ class WCV_Cron {
 		if ( $settings && array_key_exists('username_live', $settings ) && $settings[ 'username_live' ] !== '' ) {
 			add_filter( 'cron_schedules'                  , array( 'WCV_Cron', 'custom_cron_intervals' ) );
 			add_action( 'wcvendors_settings_save_payments', array( 'WCV_Cron', 'check_schedule'        ) );
-
 			add_filter( 'wcvendors_admin_settings_sanitize_option_wcvendors_payments_paypal_schedule', array( 'WCV_Cron', 'check_schedule_now' ) );
 		}
-
-		
-		// add_filter( WC_Vendors::$id . '_options_on_update', array( 'WCV_Cron', 'check_schedule_now' ) );
+	
 	}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PayPal adaptive payments were deprecated in version 1.8 of WC Vendors Marketplace. Cron class that scheduled these payments was still being initialised. Disable for future full removal in version 3.0. 

Closes #766.

### How to test the changes in this Pull Request:

1. Added check to the constructor to not initialise if paypal adaptive payment settings are not enabled and in use