### PR TITLE
Fixed: #763 Wordpress REST API (Pages asset) & WC Vendors Marketplace

### DIFF
--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -236,6 +236,9 @@ class WCV_Vendor_Dashboard {
 		ob_start();
 
 		global $start_date, $end_date;
+		
+		// WC 3.6+ - Cart and other frontend functions are not included for REST requests.
+		include_once WC()->plugin_path() . '/includes/wc-notice-functions.php';
 
 		// Need to check if the session exists and if it doesn't create it 
 		if ( null === WC()->session ) {


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Because  WC 3.6+ - Cart and other frontend functions are not included for REST requests. So we need to include wc-notice-functions.php it will resolve conflicts with Elementor Pro.
Closes #763.

### How to test the changes in this Pull Request:

1. Install and active WC Vendors Marketplace, Elementor, Elementor Pro
2. Create a page and edit page with Elementor. Add Products widget to the page.
3. GET http://yourdomain/wp-json/wp/v2/pages?per_page=20 API with per_page parameter more than 15
4. See no error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
