### PR TITLE
Added: Filter hook to add CSS classes to apply for vendor label

### DIFF
--- a/classes/front/account/class-wc-account-links.php
+++ b/classes/front/account/class-wc-account-links.php
@@ -111,6 +111,8 @@ class WCV_Account_Links extends WCV_Vendor_Signup {
 				self::apply_form_dashboard();
 			}
 
+			$label_css_classes = apply_filters( 'wcvendors_vendor_registration_label_classes', 'apply_for_vendor_label' );
+
 			require_once wcv_plugin_dir . 'templates/dashboard/denied.php';
 		}
 	}

--- a/classes/front/account/class-wc-account-links.php
+++ b/classes/front/account/class-wc-account-links.php
@@ -111,8 +111,8 @@ class WCV_Account_Links extends WCV_Vendor_Signup {
 				self::apply_form_dashboard();
 			}
 
-			$label_css_classes      = apply_filters( 'wcvendors_vendor_registration_label_css_classes', 'apply_for_vendor_label ' );
-			$term_label_css_classes = apply_filters( 'wcvendors_vendor_registration_term_label_css_classes', 'agree_to_terms_label ' );
+			$apply_label_css_classes = apply_filters( 'wcvendors_vendor_registration_apply_label_css_classes', 'apply_for_vendor_label ' );
+			$term_label_css_classes  = apply_filters( 'wcvendors_vendor_registration_term_label_css_classes', 'agree_to_terms_label ' );
 
 			require_once wcv_plugin_dir . 'templates/dashboard/denied.php';
 		}

--- a/classes/front/account/class-wc-account-links.php
+++ b/classes/front/account/class-wc-account-links.php
@@ -111,7 +111,7 @@ class WCV_Account_Links extends WCV_Vendor_Signup {
 				self::apply_form_dashboard();
 			}
 
-			$label_css_classes = apply_filters( 'wcvendors_vendor_registration_label_classes', 'apply_for_vendor_label' );
+			$label_css_classes = apply_filters( 'wcvendors_vendor_registration_label_css_classes', 'apply_for_vendor_label' );
 
 			require_once wcv_plugin_dir . 'templates/dashboard/denied.php';
 		}

--- a/classes/front/account/class-wc-account-links.php
+++ b/classes/front/account/class-wc-account-links.php
@@ -111,7 +111,8 @@ class WCV_Account_Links extends WCV_Vendor_Signup {
 				self::apply_form_dashboard();
 			}
 
-			$label_css_classes = apply_filters( 'wcvendors_vendor_registration_label_css_classes', 'apply_for_vendor_label' );
+			$label_css_classes      = apply_filters( 'wcvendors_vendor_registration_label_css_classes', 'apply_for_vendor_label ' );
+			$term_label_css_classes = apply_filters( 'wcvendors_vendor_registration_term_label_css_classes', 'agree_to_terms_label ' );
 
 			require_once wcv_plugin_dir . 'templates/dashboard/denied.php';
 		}

--- a/classes/front/signup/class-vendor-signup.php
+++ b/classes/front/signup/class-vendor-signup.php
@@ -41,8 +41,9 @@ class WCV_Vendor_Signup {
 	 *
 	 */
 	public function vendor_option() {
-		$label_css_classes     = apply_filters( 'wcvendors_vendor_registration_label_css_classes', 'apply_for_vendor_label' );
-		$become_a_vendor_label = strtolower( __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ), 'wc-vendors' ) );
+		$label_css_classes      = apply_filters( 'wcvendors_vendor_registration_label_css_classes', 'apply_for_vendor_label ' );
+		$term_label_css_classes = apply_filters( 'wcvendors_vendor_registration_term_label_css_classes', 'agree_to_terms_label ' );
+		$become_a_vendor_label  = strtolower( __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ), 'wc-vendors' ) );
 
 		apply_filters( 'wcvendors_vendor_signup_path', include_once 'views/html-vendor-signup.php' );
 	}

--- a/classes/front/signup/class-vendor-signup.php
+++ b/classes/front/signup/class-vendor-signup.php
@@ -41,7 +41,7 @@ class WCV_Vendor_Signup {
 	 *
 	 */
 	public function vendor_option() {
-		$label_css_classes     = apply_filters( 'wcvendors_vendor_registration_label_classes', 'apply_for_vendor_label' );
+		$label_css_classes     = apply_filters( 'wcvendors_vendor_registration_label_css_classes', 'apply_for_vendor_label' );
 		$become_a_vendor_label = strtolower( __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ), 'wc-vendors' ) );
 
 		apply_filters( 'wcvendors_vendor_signup_path', include_once 'views/html-vendor-signup.php' );

--- a/classes/front/signup/class-vendor-signup.php
+++ b/classes/front/signup/class-vendor-signup.php
@@ -41,7 +41,7 @@ class WCV_Vendor_Signup {
 	 *
 	 */
 	public function vendor_option() {
-
+		$label_css_classes     = apply_filters( 'wcvendors_vendor_registration_label_classes', 'apply_for_vendor_label' );
 		$become_a_vendor_label = strtolower( __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ), 'wc-vendors' ) );
 
 		apply_filters( 'wcvendors_vendor_signup_path', include_once 'views/html-vendor-signup.php' );

--- a/classes/front/signup/class-vendor-signup.php
+++ b/classes/front/signup/class-vendor-signup.php
@@ -41,7 +41,7 @@ class WCV_Vendor_Signup {
 	 *
 	 */
 	public function vendor_option() {
-		$label_css_classes      = apply_filters( 'wcvendors_vendor_registration_label_css_classes', 'apply_for_vendor_label ' );
+		$apply_label_css_classes = apply_filters( 'wcvendors_vendor_registration_apply_label_css_classes', 'apply_for_vendor_label ' );
 		$term_label_css_classes = apply_filters( 'wcvendors_vendor_registration_term_label_css_classes', 'agree_to_terms_label ' );
 		$become_a_vendor_label  = strtolower( __( get_option( 'wcvendors_label_become_a_vendor', __( 'Become a ', 'wc-vendors' ) ), 'wc-vendors' ) );
 

--- a/classes/front/signup/views/html-vendor-signup.php
+++ b/classes/front/signup/views/html-vendor-signup.php
@@ -17,7 +17,7 @@
 <?php do_action( 'wcvendors_login_apply_for_vendor_before' ); ?>
 
 <p>
-	<label for="apply_for_vendor" class="<?php echo esc_attr( $label_css_classes ); ?>">
+	<label for="apply_for_vendor" class="<?php echo esc_attr( $apply_label_css_classes ); ?>">
 		<input class="input-checkbox"
 		       id="apply_for_vendor" <?php checked( isset( $_POST['apply_for_vendor'] ), true ); ?> type="checkbox"
 		       name="apply_for_vendor" value="1"/>

--- a/classes/front/signup/views/html-vendor-signup.php
+++ b/classes/front/signup/views/html-vendor-signup.php
@@ -41,7 +41,7 @@
 	?>
 	<input type="hidden" id="terms_and_conditions_visibility" value="<?php echo $terms_and_conditions_visibility; ?>"/>
 	<p class="agree-to-terms-container" style="display: <?php echo $display; ?>">
-		<label for="agree_to_terms">
+		<label for="agree_to_terms" class="<?php echo esc_attr( $term_label_css_classes ); ?>">
 			<input class="input-checkbox"
 			       id="agree_to_terms" <?php checked( isset( $_POST['agree_to_terms'] ), true ); ?> type="checkbox"
 			       name="agree_to_terms" value="1"/>

--- a/classes/front/signup/views/html-vendor-signup.php
+++ b/classes/front/signup/views/html-vendor-signup.php
@@ -17,7 +17,7 @@
 <?php do_action( 'wcvendors_login_apply_for_vendor_before' ); ?>
 
 <p>
-	<label for="apply_for_vendor">
+	<label for="apply_for_vendor" class="<?php echo esc_attr( $label_css_classes ); ?>">
 		<input class="input-checkbox"
 		       id="apply_for_vendor" <?php checked( isset( $_POST['apply_for_vendor'] ), true ); ?> type="checkbox"
 		       name="apply_for_vendor" value="1"/>

--- a/templates/dashboard/denied.php
+++ b/templates/dashboard/denied.php
@@ -54,7 +54,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					       id="agree_to_terms" <?php checked( isset( $_POST['agree_to_terms'] ), true ); ?>
 					       type="checkbox" name="agree_to_terms" value="1"/>
 					<label for="agree_to_terms"
-					       class="checkbox"><?php printf( __( 'I have read and accepted the <a href="%s">terms and conditions</a>', 'wc-vendors' ), get_permalink( $terms_page ) ); ?></label>
+					       class="checkbox <?php echo esc_attr( $term_label_css_classes ); ?>"><?php printf( __( 'I have read and accepted the <a href="%s">terms and conditions</a>', 'wc-vendors' ), get_permalink( $terms_page ) ); ?></label>
 				</p>
 
 				<script type="text/javascript">

--- a/templates/dashboard/denied.php
+++ b/templates/dashboard/denied.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				       id="apply_for_vendor" <?php checked( isset( $_POST['apply_for_vendor'] ), true ); ?>
 				       type="checkbox" name="apply_for_vendor" value="1"/>
 				<label for="apply_for_vendor"
-				       class="checkbox <?php echo esc_attr( $label_css_classes ); ?>"><?php echo apply_filters( 'wcvendors_vendor_registration_checkbox', sprintf( __( 'Apply to become a %s? ', 'wc-vendors' ), wcv_get_vendor_name( true, false ) ) ); ?></label>
+				       class="checkbox <?php echo esc_attr( $apply_label_css_classes ); ?>"><?php echo apply_filters( 'wcvendors_vendor_registration_checkbox', sprintf( __( 'Apply to become a %s? ', 'wc-vendors' ), wcv_get_vendor_name( true, false ) ) ); ?></label>
 			</p>
 
 			<div class="clear"></div>

--- a/templates/dashboard/denied.php
+++ b/templates/dashboard/denied.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				       id="apply_for_vendor" <?php checked( isset( $_POST['apply_for_vendor'] ), true ); ?>
 				       type="checkbox" name="apply_for_vendor" value="1"/>
 				<label for="apply_for_vendor"
-				       class="checkbox"><?php echo apply_filters( 'wcvendors_vendor_registration_checkbox', sprintf( __( 'Apply to become a %s? ', 'wc-vendors' ), wcv_get_vendor_name( true, false ) ) ); ?></label>
+				       class="checkbox <?php echo esc_attr( $label_css_classes ); ?>"><?php echo apply_filters( 'wcvendors_vendor_registration_checkbox', sprintf( __( 'Apply to become a %s? ', 'wc-vendors' ), wcv_get_vendor_name( true, false ) ) ); ?></label>
 			</p>
 
 			<div class="clear"></div>


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Added: `wcvendors_vendor_registration_label_css_classes` filter hook

### How to test the changes in this Pull Request:

1. Add an example code snippet below to your `functions.php`
2. Go to my-account
3. See `Apply to become a vendor?` label have class `example_css_class`

Code snippet: 
```
/**
 * Add CSS class to apply for vendor label in a registration
 *
 * @param  string $class css classes.
 * @return string
 */
function add_apply_vendor_label_css_class( $class ) {
	$class .= 'example_css_class';

	return $class;
}
add_filter( 'wcvendors_vendor_registration_apply_label_css_classes', 'add_apply_vendor_label_css_class', 10, 1 ); 
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
