### PR TITLE
Update sales report to compatibility with refund update

### DIFF
--- a/classes/admin/class-wcv-commissions-csv-exporter.php
+++ b/classes/admin/class-wcv-commissions-csv-exporter.php
@@ -183,8 +183,12 @@ class WCV_Commissions_CSV_Export extends WC_CSV_Exporter {
 						break;
 					case 'shipped': 
 						$order = wc_get_order( $commission->order_id );
-						$shipped = get_post_meta( $order->get_id(), 'wc_pv_shipped', true ); 
-						$value = ! empty( $shipped ) && in_array( $commission->vendor_id, $shipped ) ? __( 'Yes', 'wc-vendors' ) : __( 'No', 'wc-vendors'); 
+						if ( $order ){ 
+							$shipped = get_post_meta( $order->get_id(), 'wc_pv_shipped', true ); 
+							$value = ! empty( $shipped ) && in_array( $commission->vendor_id, $shipped ) ? __( 'Yes', 'wc-vendors' ) : __( 'No', 'wc-vendors'); 
+						} else{ 
+							$value = '-';
+						}
 						break; 
 					default:
 						$value = $commission->$column_id;

--- a/classes/admin/settings/class-wcv-settings-commission.php
+++ b/classes/admin/settings/class-wcv-settings-commission.php
@@ -76,8 +76,8 @@ if ( ! class_exists( 'WCVendors_Settings_Commission', false ) ) :
 							'type'    => 'number',
 						),
 						array(
-							'title'   => __( 'Show reversed orders', 'wcvendors-pro' ),
-							'desc'    => __( 'Show reversed / refunded orders on the order dashboard', 'wcvendors-pro' ),
+							'title'   => __( 'Show reversed orders', 'wc-vendors' ),
+							'desc'    => __( 'Show reversed / refunded orders on the order dashboard', 'wc-vendors' ),
 							'id'      => 'wcvendors_dashboard_orders_show_reversed_orders',
 							'type'    => 'checkbox',
 							'default' => 'no',

--- a/classes/admin/settings/class-wcv-settings-commission.php
+++ b/classes/admin/settings/class-wcv-settings-commission.php
@@ -76,6 +76,13 @@ if ( ! class_exists( 'WCVendors_Settings_Commission', false ) ) :
 							'type'    => 'number',
 						),
 						array(
+							'title'   => __( 'Show reversed orders', 'wcvendors-pro' ),
+							'desc'    => __( 'Show reversed / refunded orders on the order dashboard', 'wcvendors-pro' ),
+							'id'      => 'wcvendors_dashboard_orders_show_reversed_orders',
+							'type'    => 'checkbox',
+							'default' => 'no',
+						),
+						array(
 							'type' => 'sectionend',
 							'id'   => 'commission_options',
 						),

--- a/classes/class-queries.php
+++ b/classes/class-queries.php
@@ -13,17 +13,20 @@ class WCV_Queries {
 	public static function get_commission_products( $user_id ) {
 		global $wpdb;
 
-		$dates           = self::orders_within_range();
-		$vendor_products = array();
-		$sql             = '';
-
-		$sql .= "SELECT product_id FROM {$wpdb->prefix}pv_commission WHERE vendor_id = {$user_id} ";
+		$dates                = self::orders_within_range();
+		$vendor_products      = array();
+		$sql                  = '';
+		$show_reversed_orders = wcv_is_show_reversed_order();
+		$sql                 .= "SELECT product_id FROM {$wpdb->prefix}pv_commission WHERE vendor_id = {$user_id} ";
 
 		if ( ! empty( $dates ) ) {
 			$sql .= "AND time >= '" . $dates['after'] . "' AND time <= '" . $dates['before'] . "'";
 		}
 
-		$sql .= " AND status != 'reversed' GROUP BY product_id";
+		if ( ! $show_reversed_orders ) {
+			$sql .= " AND status != 'reversed' ";
+		}
+		$sql .= ' GROUP BY product_id';
 
 		$results = $wpdb->get_results( $sql );
 
@@ -108,29 +111,18 @@ class WCV_Queries {
 		);
 
 		$args = wp_parse_args( $args, $defaults );
-
-		$sql = "
-			SELECT order_id
-			FROM {$wpdb->prefix}pv_commission as order_items
-			WHERE   product_id IN ('" . implode( "','", $product_ids ) . "')
-			AND 	time >= '" . $args['dates']['after'] . "'
-			AND 	time <= '" . $args['dates']['before'] . "'";
+		$sql  = "SELECT order_id FROM {$wpdb->prefix}pv_commission as order_items WHERE product_id IN ('" . implode( "','", $product_ids ) . "')";
+		$sql .= "AND time >= '" . $args['dates']['after'] . "'AND time <= '" . $args['dates']['before'] . "'";
 
 		if ( ! $show_reversed_orders ) {
 			$sql .= " AND status != 'reversed'";
 		}
 
 		if ( ! empty( $args['vendor_id'] ) ) {
-			$sql .= "
-				AND vendor_id = {$args['vendor_id']}
-			";
+			$sql .= " AND vendor_id = {$args['vendor_id']}";
 		}
 
-		$sql .= '
-			GROUP BY order_id
-			ORDER BY time DESC
-		';
-
+		$sql   .= ' GROUP BY order_id ORDER BY time DESC';
 		$orders = $wpdb->get_results( $sql );
 
 		return $orders;

--- a/classes/class-queries.php
+++ b/classes/class-queries.php
@@ -60,10 +60,10 @@ class WCV_Queries {
 
 		$vendor_products      = array();
 		$vendor_id            = get_current_user_id();
-		$hide_reversed_orders = wc_string_to_bool( get_option( 'wcvendors_dashboard_orders_show_reversed_orders', 'no' ) );
+		$show_reversed_orders = wcv_is_show_reversed_order();
 		$sql                  = "SELECT product_id FROM {$wpdb->prefix}pv_commission WHERE order_id = {$order_id} ";
 
-		if ( false === $hide_reversed_orders ) {
+		if ( ! $show_reversed_orders ) {
 			$sql .= " AND status != 'reversed'";
 		}
 
@@ -96,8 +96,8 @@ class WCV_Queries {
 		if ( empty( $product_ids ) ) {
 			return false;
 		}
-		$hide_reversed_orders = wc_string_to_bool( get_option( 'wcvendors_dashboard_orders_show_reversed_orders', 'no' ) );
-		$dates = self::orders_within_range();
+		$show_reversed_orders = wcv_is_show_reversed_order();
+		$dates                = self::orders_within_range();
 
 		$defaults = array(
 			'status' => apply_filters( 'wcvendors_completed_statuses', array( 'completed', 'processing' ) ),
@@ -116,7 +116,7 @@ class WCV_Queries {
 			AND 	time >= '" . $args['dates']['after'] . "'
 			AND 	time <= '" . $args['dates']['before'] . "'";
 
-		if ( false === $hide_reversed_orders ) {
+		if ( ! $show_reversed_orders ) {
 			$sql .= " AND status != 'reversed'";
 		}
 

--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -278,7 +278,7 @@ class WCV_Vendor_Dashboard {
 		}
 
 		$vendor_summary = $this->format_product_details( $vendor_products );
-		$order_summary  = WCV_Queries::get_orders_for_products( $products );
+		$order_summary  = WCV_Queries::get_orders_for_products( $products, array( 'vendor_id' => $user_id ) );
 
 		$providers      = array();
 		$provider_array = array();

--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -312,8 +312,8 @@ class WCV_Vendor_Dashboard {
 
 		if ( wc_string_to_bool( get_option( 'wcvendors_capability_frontend_reports', 'yes' ) ) ) {
 
-			$can_view_address = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_shipping', 'yes' ) );
-
+			$can_view_address     = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_shipping', 'yes' ) );
+			$show_reversed_orders = wcv_is_show_reversed_order();
 			wc_get_template(
 				'reports.php',
 				array(
@@ -341,6 +341,7 @@ class WCV_Vendor_Dashboard {
 				'provider_array'   => $provider_array,
 				'can_view_orders'  => $can_view_orders,
 				'can_view_address' => $can_view_address,
+				'show_reversed'    => $show_reversed_orders,
 			),
 			'wc-vendors/dashboard/',
 			wcv_plugin_dir . 'templates/dashboard/'

--- a/classes/front/orders/class-orders.php
+++ b/classes/front/orders/class-orders.php
@@ -300,6 +300,7 @@ class WCV_Orders {
 			}
 
 			$items[ $i ]['total_qty'] = 0;
+			$is_full_refuned          = $order->get_total_refunded() == $order->get_total();
 			foreach ( $order->get_items() as $line_id => $item ) {
 
 				if ( $item['product_id'] != $product_id && $item['variation_id'] != $product_id ) {
@@ -309,6 +310,10 @@ class WCV_Orders {
 				$refund_total = $order->get_total_refunded_for_item( $item->get_id() );
 				$refund_qty   = $order->get_qty_refunded_for_item( $item->get_id() );
 
+				if ( $is_full_refuned ) {
+					$refund_total = $item['line_total'];
+					$refund_qty   = $item['qty'];
+				}
 				if ( ( $refund_total > 0 ) && $item->get_product_id() == $product_id || $item->get_variation_id() == $product_id ) {
 					$items[ $i ]['refund'] = array(
 						'total' => $refund_total,

--- a/classes/front/orders/class-orders.php
+++ b/classes/front/orders/class-orders.php
@@ -254,6 +254,11 @@ class WCV_Orders {
 		foreach ( $orders as $i => $order ) {
 			$i          = $order->order_id;
 			$order      = wc_get_order( $i );
+
+			if ( is_bool( $order ) ) {
+				continue;
+			}
+
 			$order_date = $order->get_date_created();
 
 			$shipping_first_name = $order->get_shipping_first_name();
@@ -299,6 +304,17 @@ class WCV_Orders {
 
 				if ( $item['product_id'] != $product_id && $item['variation_id'] != $product_id ) {
 					continue;
+				}
+
+				$refund_total = $order->get_total_refunded_for_item( $item->get_id() );
+				$refund_qty   = $order->get_qty_refunded_for_item( $item->get_id() );
+
+				if ( ( $refund_total > 0 ) && $item->get_product_id() == $product_id || $item->get_variation_id() == $product_id ) {
+					$items[ $i ]['refund'] = array(
+						'total' => $refund_total,
+						'qty'   => absint( $refund_qty ),
+					);
+
 				}
 
 				$items[ $i ]['items'][]   = $item;

--- a/classes/front/orders/class-orders.php
+++ b/classes/front/orders/class-orders.php
@@ -19,7 +19,7 @@ class WCV_Orders {
 		$this->can_view_orders        = wc_string_to_bool( get_option( 'wcvendors_capability_orders_enabled', 'no' ) );
 		$this->can_export_csv         = wc_string_to_bool( get_option( 'wcvendors_capability_orders_export', 'no' ) );
 		$this->can_view_emails        = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_email', 'no' ) );
-		$this->can_view_name     	  = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_name', 'no' ) );
+		$this->can_view_name          = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_name', 'no' ) );
 		$this->can_view_shipping_name = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_shipping_name', 'no' ) );
 		$this->can_view_address       = wc_string_to_bool( get_option( 'wcvendors_capability_order_customer_shipping' ) );
 
@@ -99,8 +99,8 @@ class WCV_Orders {
 			return false;
 		}
 
-		extract( WCV_Orders::format_order_details( $this->orders, $this->product_id ) );
-		$headers = WCV_Orders::get_headers();
+		extract( self::format_order_details( $this->orders, $this->product_id ) );
+		$headers = self::get_headers();
 
 		// Export the CSV
 		require_once wcv_plugin_dir . 'classes/front/orders/class-export-csv.php';
@@ -161,8 +161,8 @@ class WCV_Orders {
 			exit;
 		}
 
-		$headers = WCV_Orders::get_headers();
-		$all     = WCV_Orders::format_order_details( $this->orders, $this->product_id );
+		$headers = self::get_headers();
+		$all     = self::format_order_details( $this->orders, $this->product_id );
 
 		wp_enqueue_script( 'pv_frontend_script', wcv_assets_url . 'js/front-orders.js' );
 
@@ -187,14 +187,17 @@ class WCV_Orders {
 		}
 
 		wc_get_template(
-			'orders.php', array(
-			'headers'        => $headers,
-			'body'           => $all['body'],
-			'items'          => $all['items'],
-			'product_id'     => $all['product_id'],
-			'providers'      => $providers,
-			'provider_array' => $provider_array,
-		), 'wc-vendors/orders/', wcv_plugin_dir . 'templates/orders/'
+			'orders.php',
+			array(
+				'headers'        => $headers,
+				'body'           => $all['body'],
+				'items'          => $all['items'],
+				'product_id'     => $all['product_id'],
+				'providers'      => $providers,
+				'provider_array' => $provider_array,
+			),
+			'wc-vendors/orders/',
+			wcv_plugin_dir . 'templates/orders/'
 		);
 
 	} // display_product_orders()
@@ -252,8 +255,8 @@ class WCV_Orders {
 		$product = wc_get_product( $product_id )->get_title();
 
 		foreach ( $orders as $i => $order ) {
-			$i          = $order->order_id;
-			$order      = wc_get_order( $i );
+			$i     = $order->order_id;
+			$order = wc_get_order( $i );
 
 			if ( is_bool( $order ) ) {
 				continue;
@@ -300,7 +303,7 @@ class WCV_Orders {
 			}
 
 			$items[ $i ]['total_qty'] = 0;
-			$is_full_refuned          = $order->get_total_refunded() == $order->get_total();
+			$is_full_refunded         = $order->get_total_refunded() == $order->get_total();
 			foreach ( $order->get_items() as $line_id => $item ) {
 
 				if ( $item['product_id'] != $product_id && $item['variation_id'] != $product_id ) {
@@ -310,7 +313,7 @@ class WCV_Orders {
 				$refund_total = $order->get_total_refunded_for_item( $item->get_id() );
 				$refund_qty   = $order->get_qty_refunded_for_item( $item->get_id() );
 
-				if ( $is_full_refuned ) {
+				if ( $is_full_refunded ) {
 					$refund_total = $item['line_total'];
 					$refund_qty   = $item['qty'];
 				}
@@ -322,7 +325,7 @@ class WCV_Orders {
 
 				}
 
-				$items[ $i ]['items'][]   = $item;
+				$items[ $i ]['items'][]    = $item;
 				$items[ $i ]['total_qty'] += $item['qty'];
 			}
 		}

--- a/classes/front/orders/class-orders.php
+++ b/classes/front/orders/class-orders.php
@@ -14,7 +14,7 @@ class WCV_Orders {
 	/**
 	 * __construct()
 	 */
-	function __construct() {
+	public function __construct() {
 
 		$this->can_view_orders        = wc_string_to_bool( get_option( 'wcvendors_capability_orders_enabled', 'no' ) );
 		$this->can_export_csv         = wc_string_to_bool( get_option( 'wcvendors_capability_orders_export', 'no' ) );
@@ -311,16 +311,13 @@ class WCV_Orders {
 				}
 
 				$refund_total = $order->get_total_refunded_for_item( $item->get_id() );
-				$refund_qty   = $order->get_qty_refunded_for_item( $item->get_id() );
 
 				if ( $is_full_refunded ) {
 					$refund_total = $item['line_total'];
-					$refund_qty   = $item['qty'];
 				}
 				if ( ( $refund_total > 0 ) && $item->get_product_id() == $product_id || $item->get_variation_id() == $product_id ) {
 					$items[ $i ]['refund'] = array(
 						'total' => $refund_total,
-						'qty'   => absint( $refund_qty ),
 					);
 
 				}

--- a/classes/includes/class-functions.php
+++ b/classes/includes/class-functions.php
@@ -140,3 +140,33 @@ if ( ! function_exists( 'wcv_set_primary_vendor_role' ) ){
 		}
 	}
 }
+
+if ( ! function_exists( 'wcv_is_pro_active' ) ) {
+
+	/**
+	 * Check if the pro plugin is active
+	 *
+	 * @since 2.4.0
+	 * @return bool
+	 */
+	function wcv_is_pro_active() {
+		return class_exists( 'WCVendors_Pro' );
+	}
+}
+
+if ( ! function_exists( 'wcv_is_show_reversed_order' ) ) {
+
+	/**
+	 * Check show reversed order
+	 *
+	 * @since 2.4.0
+	 * @return bool
+	 */
+	function wcv_is_show_reversed_order() {
+		if ( wcv_is_pro_active() ) {
+			return wc_string_to_bool( get_option( 'wcvendors_dashboard_orders_show_reversed_orders', 'no' ) );
+		}
+
+		return apply_filters( 'wcvendors_show_reversed_orders', true );
+	}
+}

--- a/classes/includes/class-functions.php
+++ b/classes/includes/class-functions.php
@@ -141,19 +141,6 @@ if ( ! function_exists( 'wcv_set_primary_vendor_role' ) ){
 	}
 }
 
-if ( ! function_exists( 'wcv_is_pro_active' ) ) {
-
-	/**
-	 * Check if the pro plugin is active
-	 *
-	 * @since 2.4.0
-	 * @return bool
-	 */
-	function wcv_is_pro_active() {
-		return class_exists( 'WCVendors_Pro' );
-	}
-}
-
 if ( ! function_exists( 'wcv_is_show_reversed_order' ) ) {
 
 	/**
@@ -163,10 +150,8 @@ if ( ! function_exists( 'wcv_is_show_reversed_order' ) ) {
 	 * @return bool
 	 */
 	function wcv_is_show_reversed_order() {
-		if ( wcv_is_pro_active() ) {
-			return wc_string_to_bool( get_option( 'wcvendors_dashboard_orders_show_reversed_orders', 'no' ) );
-		}
 
-		return apply_filters( 'wcvendors_show_reversed_orders', true );
+		return wc_string_to_bool( get_option( 'wcvendors_dashboard_orders_show_reversed_orders', 'no' ) );
+
 	}
 }

--- a/templates/dashboard/orders.php
+++ b/templates/dashboard/orders.php
@@ -61,7 +61,7 @@ if ( function_exists( 'wc_print_notices' ) ) {
 
 	<?php
 	if ( ! empty( $order_summary ) ) :
-		$totals = 0;
+		$totals  = 0;
 		$user_id = get_current_user_id();
 		?>
 
@@ -74,9 +74,9 @@ if ( function_exists( 'wc_print_notices' ) ) {
 				continue;
 			}
 
-			$order_id = $order->get_id();
-			$valid_items = WCV_Queries::get_products_for_order( $order_id );
-			$valid = array();
+			$order_id       = $order->get_id();
+			$valid_items    = WCV_Queries::get_products_for_order( $order_id );
+			$valid          = array();
 			$needs_shipping = false;
 
 			$items = $order->get_items();
@@ -104,10 +104,10 @@ if ( function_exists( 'wc_print_notices' ) ) {
 				<?php endif; ?>
 				<td>
 					<?php
-					$sum    = WCV_Queries::sum_for_orders( array( $order_id ), array( 'vendor_id' => get_current_user_id() ) );
+					$sum   = WCV_Queries::sum_for_orders( array( $order_id ), array( 'vendor_id' => get_current_user_id() ) );
 					$total = 0;
 					if ( 0 < count( $sum ) ) {
-						$total  = $sum[0]->line_total;
+						$total   = $sum[0]->line_total;
 						$totals += $total;
 					}
 					echo wc_price( $total );
@@ -166,18 +166,18 @@ if ( function_exists( 'wc_print_notices' ) ) {
 			<tr id="view-items-<?php echo $order_id; ?>" style="display:none;">
 				<td colspan="5">
 					<?php
-					$product_id = '';
-					$refunded   = array();
-					$order_refunded = $order->get_total_refunded();
-					$is_full_refuned = $order_refunded == $order->get_total();
+					$product_id       = '';
+					$refunded         = array();
+					$order_refunded   = $order->get_total_refunded();
+					$is_full_refunded = $order_refunded == $order->get_total();
 
 					foreach ( $valid as $key => $item ) :
 
 						// Get variation data if there is any.
 						$variation_detail = ! empty( $item['variation_id'] ) ? WCV_Orders::get_variation_data( $item['variation_id'] ) : '';
-						$refunded_total   =  $order->get_total_refunded_for_item( $item->get_id() );
+						$refunded_total   = $order->get_total_refunded_for_item( $item->get_id() );
 
-						if ( $is_full_refuned ) {
+						if ( $is_full_refunded ) {
 							$refunded_total = $item['line_total'];
 						}
 
@@ -189,14 +189,14 @@ if ( function_exists( 'wc_print_notices' ) ) {
 						}
 
 						if ( $refunded_total > 0 ) {
-							$refunded_qty = $is_full_refuned ? ( -1 * $item['qty'] ) : $order->get_qty_refunded_for_item( $item->get_id() );
+							$refunded_qty = $is_full_refunded ? ( -1 * $item['qty'] ) : $order->get_qty_refunded_for_item( $item->get_id() );
 							$refunded[]   = $refunded_qty . ' x ' . wc_price( $refunded_total ) . ' x ' . $item['name'];
 						}
 						?>
 
 					<?php endforeach; ?>
 					<?php if ( ! empty( $refunded ) ) : ?>
-						<br/><strong><?php echo esc_html__( 'Refuned:', 'wc-vendors' ); ?></strong>
+						<br/><strong><?php echo esc_html__( 'Refunded:', 'wc-vendors' ); ?></strong>
 						<?php echo implode( ', ', $refunded ); ?>
 					<?php endif; ?>
 
@@ -205,17 +205,20 @@ if ( function_exists( 'wc_print_notices' ) ) {
 
 			<?php if ( class_exists( 'WC_Shipment_Tracking' ) ) : ?>
 
-			<?php if ( is_array( $providers ) ) : ?>
+				<?php if ( is_array( $providers ) ) : ?>
 				<tr id="view-tracking-<?php echo $order_id; ?>" style="display:none;">
 					<td colspan="5">
 						<div class="order-tracking">
 							<?php
 							wc_get_template(
-								'shipping-form.php', array(
-								'order_id'   => $order_id,
-								'product_id' => $product_id,
-								'providers'  => $providers,
-							), 'wc-vendors/orders/shipping/', wcv_plugin_dir . 'templates/orders/shipping/'
+								'shipping-form.php',
+								array(
+									'order_id'   => $order_id,
+									'product_id' => $product_id,
+									'providers'  => $providers,
+								),
+								'wc-vendors/orders/shipping/',
+								wcv_plugin_dir . 'templates/orders/shipping/'
 							);
 							?>
 						</div>
@@ -237,7 +240,7 @@ if ( function_exists( 'wc_print_notices' ) ) {
 
 		<tr>
 			<td colspan="4"
-			    style="text-align:center;"><?php _e( 'You have no orders during this period.', 'wc-vendors' ); ?></td>
+				style="text-align:center;"><?php _e( 'You have no orders during this period.', 'wc-vendors' ); ?></td>
 		</tr>
 
 	<?php endif; ?>

--- a/templates/dashboard/orders.php
+++ b/templates/dashboard/orders.php
@@ -69,6 +69,11 @@ if ( function_exists( 'wc_print_notices' ) ) {
 		foreach ( $order_summary as $order ) :
 
 			$order = wc_get_order( $order->order_id );
+
+			if ( is_bool( $order ) ) {
+				continue;
+			}
+
 			$order_id = $order->get_id();
 			$valid_items = WCV_Queries::get_products_for_order( $order_id );
 			$valid = array();
@@ -162,21 +167,30 @@ if ( function_exists( 'wc_print_notices' ) ) {
 				<td colspan="5">
 					<?php
 					$product_id = '';
+					$refunded   = array();
 					foreach ( $valid as $key => $item ) :
 
 						// Get variation data if there is any.
 						$variation_detail = ! empty( $item['variation_id'] ) ? WCV_Orders::get_variation_data( $item['variation_id'] ) : '';
-
+						$refunded_total   =  $order->get_total_refunded_for_item( $item->get_id() );
 						?>
 						<?php echo $item['qty'] . 'x ' . $item['name']; ?>
 						<?php
 						if ( ! empty( $variation_detail ) ) {
 							echo '<br />' . $variation_detail;
 						}
+
+						if ( $refunded_total > 0 ) {
+							$refunded_qty = $order->get_qty_refunded_for_item( $item->get_id() );
+							$refunded[]   = $refunded_qty . ' x ' . wc_price( $refunded_total ) . ' x ' . $item['name'];
+						}
 						?>
 
-
 					<?php endforeach; ?>
+					<?php if ( ! empty( $refunded ) ) : ?>
+						<br/><strong><?php echo esc_html__( 'Refuned:', 'wc-vendors' ); ?></strong>
+						<?php echo implode( ', ', $refunded ); ?>
+					<?php endif; ?>
 
 				</td>
 			</tr>

--- a/templates/dashboard/orders.php
+++ b/templates/dashboard/orders.php
@@ -189,8 +189,7 @@ if ( function_exists( 'wc_print_notices' ) ) {
 						}
 
 						if ( $refunded_total > 0 ) {
-							$refunded_qty = $is_full_refunded ? $item['qty'] : $order->get_qty_refunded_for_item( $item->get_id() );
-							$refunded[]   = absint( $refunded_qty ) . 'x ' . wc_price( $refunded_total ) . ' - ' . $item['name'];
+							$refunded[]   = wc_price( $refunded_total ) . ' - ' . $item['name'];
 						}
 						?>
 

--- a/templates/dashboard/orders.php
+++ b/templates/dashboard/orders.php
@@ -168,11 +168,19 @@ if ( function_exists( 'wc_print_notices' ) ) {
 					<?php
 					$product_id = '';
 					$refunded   = array();
+					$order_refunded = $order->get_total_refunded();
+					$is_full_refuned = $order_refunded == $order->get_total();
+
 					foreach ( $valid as $key => $item ) :
 
 						// Get variation data if there is any.
 						$variation_detail = ! empty( $item['variation_id'] ) ? WCV_Orders::get_variation_data( $item['variation_id'] ) : '';
 						$refunded_total   =  $order->get_total_refunded_for_item( $item->get_id() );
+
+						if ( $is_full_refuned ) {
+							$refunded_total = $item['line_total'];
+						}
+
 						?>
 						<?php echo $item['qty'] . 'x ' . $item['name']; ?>
 						<?php
@@ -181,7 +189,7 @@ if ( function_exists( 'wc_print_notices' ) ) {
 						}
 
 						if ( $refunded_total > 0 ) {
-							$refunded_qty = $order->get_qty_refunded_for_item( $item->get_id() );
+							$refunded_qty = $is_full_refuned ? ( -1 * $item['qty'] ) : $order->get_qty_refunded_for_item( $item->get_id() );
 							$refunded[]   = $refunded_qty . ' x ' . wc_price( $refunded_total ) . ' x ' . $item['name'];
 						}
 						?>

--- a/templates/dashboard/orders.php
+++ b/templates/dashboard/orders.php
@@ -189,13 +189,13 @@ if ( function_exists( 'wc_print_notices' ) ) {
 						}
 
 						if ( $refunded_total > 0 ) {
-							$refunded_qty = $is_full_refunded ? ( -1 * $item['qty'] ) : $order->get_qty_refunded_for_item( $item->get_id() );
-							$refunded[]   = $refunded_qty . ' x ' . wc_price( $refunded_total ) . ' x ' . $item['name'];
+							$refunded_qty = $is_full_refunded ? $item['qty'] : $order->get_qty_refunded_for_item( $item->get_id() );
+							$refunded[]   = absint( $refunded_qty ) . 'x ' . wc_price( $refunded_total ) . ' - ' . $item['name'];
 						}
 						?>
 
 					<?php endforeach; ?>
-					<?php if ( ! empty( $refunded ) ) : ?>
+					<?php if ( ! empty( $refunded ) && $show_reversed ) : ?>
 						<br/><strong><?php echo esc_html__( 'Refunded:', 'wc-vendors' ); ?></strong>
 						<?php echo implode( ', ', $refunded ); ?>
 					<?php endif; ?>

--- a/templates/orders/orders.php
+++ b/templates/orders/orders.php
@@ -38,7 +38,8 @@ if ( function_exists( 'wc_print_notices' ) ) {
 	foreach ( $body as $order_id => $order ) :
 
 		$order_items = ! empty( $items[ $order_id ]['items'] ) ? $items[ $order_id ]['items'] : array();
-		$count = count( $order_items );
+		$count       = count( $order_items );
+		$refund      = isset( $items[ $order_id ]['refund'] ) ? $items[ $order_id ]['refund'] : array();
 		?>
 
 		<tr>
@@ -76,6 +77,7 @@ if ( function_exists( 'wc_print_notices' ) ) {
 					'item'     => $item,
 					'count'    => $count,
 					'order_id' => $order_id,
+					'refund'   => $refund,
 				), 'wc-vendors/orders/', wcv_plugin_dir . 'templates/orders/'
 				);
 

--- a/templates/orders/table-body.php
+++ b/templates/orders/table-body.php
@@ -34,6 +34,14 @@ if ( $count > 1 ) : ?>
 		<?php endif; ?>
 
 		<?php printf( __( 'Quantity: %d', 'wc-vendors' ), $item['qty'] ); ?>
+
+		<?php if ( $refund && !empty( $refund ) ) : ?>
+			<br />
+			<?php printf( __( 'Refunded qty: %d', 'wc-vendors' ), $refund['qty'] ); ?>
+			<br />
+			<?php printf( __( 'Refunded total: %s', 'wc-vendors' ), wc_price( $refund['total'] ) ); ?>
+		<?php endif; ?>
+
 	</td>
 
 	<?php if ( $count > 1 ) : ?>

--- a/templates/orders/table-body.php
+++ b/templates/orders/table-body.php
@@ -37,8 +37,6 @@ if ( $count > 1 ) : ?>
 
 		<?php if ( $refund && !empty( $refund ) ) : ?>
 			<br />
-			<?php printf( __( 'Refunded qty: %d', 'wc-vendors' ), $refund['qty'] ); ?>
-			<br />
 			<?php printf( __( 'Refunded total: %s', 'wc-vendors' ), wc_price( $refund['total'] ) ); ?>
 		<?php endif; ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Updated: View order screen in sales report table in Vendor Dashboard
- Updated: Orders table view items in Vendor Dashboard


### How to test the changes in this Pull Request:

1. Login as vendor account
2. Go to Vendor Dashboard
3. Click Show Orders in the Sales Report table will see refund detail if the order has been refunded
4. Click View items in the Orders table will see refund detail if the order has been refunded

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
