### PR TITLE
Update menu page parameter

### DIFF
--- a/classes/admin/class-admin-menus.php
+++ b/classes/admin/class-admin-menus.php
@@ -55,7 +55,7 @@ class WCVendors_Admin_Menus {
 			'wc-vendors',
 			array( $this, 'extensions_page' ),
 			'dashicons-cart',
-			'50'
+			50
 		);
 	}
 


### PR DESCRIPTION
The 7th parameter of add_menu_page must be an integer in WordPress 6.0
