### PR TITLE
The admin shipping fee is negative #828

### DIFF
--- a/classes/class-vendors.php
+++ b/classes/class-vendors.php
@@ -215,24 +215,29 @@ class WCV_Vendors {
 			}
 		}
 
-		// Add remainders on end to admin
-		$discount = $order->get_total_discount();
-		$shipping = round( ( $order->get_total_shipping() - $shipping_given ), 2 );
-		$tax      = round( $order->get_total_tax() - $tax_given, 2 );
-		$total    = ( $tax + $shipping ) - $discount;
+		$shipping_methods = WC()->shipping->load_shipping_methods();
+		$vendor_shipping = isset( $shipping_methods['wcv_pro_vendor_shipping'] ) ? true : false;
+		if ( ! $vendor_shipping ) {
 
-		if ( $group ) {
-			$r_total                   = round( $receiver[1]['total'], 2 );
-			$receiver[1]['commission'] = round( $receiver[1]['commission'], 2 ) - round( $discount, 2 );
-			$receiver[1]['shipping']   = $shipping;
-			$receiver[1]['tax']        = $tax;
-			$receiver[1]['total']      = $r_total + round( $total, 2 );
-		} else {
-			$r_total                           = round( $receiver[1][ $key ]['total'], 2 );
-			$receiver[1][ $key ]['commission'] = round( $receiver[1][ $key ]['commission'], 2 ) - round( $discount, 2 );
-			$receiver[1][ $key ]['shipping']   = ( $order->get_total_shipping() - $shipping_given );
-			$receiver[1][ $key ]['tax']        = $tax;
-			$receiver[1][ $key ]['total']      = $r_total + round( $total, 2 );
+			// Add remainders on end to admin
+			$discount = $order->get_total_discount();
+			$shipping = round( ( $order->get_total_shipping() - $shipping_given ), 2 );
+			$tax      = round( $order->get_total_tax() - $tax_given, 2 );
+			$total    = ( $tax + $shipping ) - $discount;
+
+			if ( $group ) {
+				$r_total                   = round( $receiver[1]['total'], 2 );
+				$receiver[1]['commission'] = round( $receiver[1]['commission'], 2 ) - round( $discount, 2 );
+				$receiver[1]['shipping']   = $shipping;
+				$receiver[1]['tax']        = $tax;
+				$receiver[1]['total']      = $r_total + round( $total, 2 );
+			} else {
+				$r_total                           = round( $receiver[1][ $key ]['total'], 2 );
+				$receiver[1][ $key ]['commission'] = round( $receiver[1][ $key ]['commission'], 2 ) - round( $discount, 2 );
+				$receiver[1][ $key ]['shipping']   = ( $order->get_total_shipping() - $shipping_given );
+				$receiver[1][ $key ]['tax']        = $tax;
+				$receiver[1][ $key ]['total']      = $r_total + round( $total, 2 );
+			}
 		}
 
 		// Reset the array keys


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #828 .

** Check if vendor shipping system is disabled then add remainders on end to admin
### How to test the changes in this Pull Request:

1. Activate WC Vendors Pro
2. Run an order with 2 or more items from the same vendor
3. Check the commission table and see shipping fee is not negative

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
