### PR TITLE
Prepare v2.4.1 for release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 Changelog for WC Vendors Marketplace
 
+Version 2.4.1 - 3rd March 2022
+
+* Updated: Sales report with refund details (#822)
+* Updated: Menu page parameter type in WordPress 6.0 (#826)
+* Reverted: "Added: Log marketplace commissions to commissions table (#806)" (#832)
+* Fixed: Undefined variable ids (#816)
+* Fixed: Order export fails if the order has been deleted #813 (#814)
+
 Version 2.4.0 - 10th January 2022
 
 * Added: Marketplace admin can mark orders shipped (#808)

--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -7,18 +7,17 @@
  * Author URI:           https://www.wcvendors.com
  * GitHub Plugin URI:    https://github.com/wcvendors/wcvendors
  *
- * Version:              2.4.0
+ * Version:              2.4.1
  * Requires at least:    5.3.0
- * Tested up to:         5.9
+ * Tested up to:         6.0
  * WC requires at least: 5.0
- * WC tested up to:      6.1.0
+ * WC tested up to:      6.2.0
  *
  * Text Domain:          wc-vendors
  * Domain Path:          /languages/
  *
  * @category             Plugin
- * @copyright            Copyright © 2012 Matt Gates
- * @copyright            Copyright © 2021 WC Vendors
+ * @copyright            Copyright © 2012 Matt Gates, Copyright © 2021 WC Vendors
  * @author               Matt Gates, WC Vendors
  * @package              WCVendors
  * @license              GPL2
@@ -107,7 +106,7 @@ if ( wcv_is_woocommerce_activated() ) {
 	 */
 	class WC_Vendors {
 
-		public $version = '2.4.0';
+		public $version = '2.4.1';
 
 		/**
 		 * @var

--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -11,7 +11,7 @@
  * Requires at least:    5.3.0
  * Tested up to:         6.0
  * WC requires at least: 5.0
- * WC tested up to:      6.2.0
+ * WC tested up to:      6.2.1
  *
  * Text Domain:          wc-vendors
  * Domain Path:          /languages/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-vendors",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "devDependencies": {
     "cypress": "^3.8.3",

--- a/readme.txt
+++ b/readme.txt
@@ -6,10 +6,10 @@ Author URI: https://www.wcvendors.com/
 Plugin URI: https://www.wcvendors.com/
 Requires at least: 5.3.0
 Requires PHP: 7.4
-Tested up to: 5.9
+Tested up to: 6.0
 WC requires at least: 5.0.0
-WC tested up to: 6.1.0
-Stable tag: 2.4.0
+WC tested up to: 6.2.0
+Stable tag: 2.4.1
 License: GPLv2 or later
 
 The original multi-vendor marketplace plugin for WordPress and WooCommerce. Best support available. 


### PR DESCRIPTION
### Changelog:

Version 2.4.1 - 3rd March 2022

* Updated: Sales report with refund details (#822)
* Updated: Menu page parameter type in WordPress 6.0 (#826)
* Reverted: "Added: Log marketplace commissions to commissions table (#806)" (#832)
* Fixed: Undefined variable ids (#816)
* Fixed: Order export fails if the order has been deleted #813 (#814)
