### PR TITLE
Fixed: Duplicate H1 tag on products

### DIFF
--- a/assets/css/wcv-store.css
+++ b/assets/css/wcv-store.css
@@ -1,0 +1,3 @@
+.wcv-shop-header-name { font-size: 2em; margin-bottom: 0.5em; }
+
+@media screen and (max-width: 768px) { .wcv-shop-header-name { font-size: 1.5em; } }

--- a/assets/css/wcv-store.min.css
+++ b/assets/css/wcv-store.min.css
@@ -1,0 +1,1 @@
+.wcv-shop-header-name{font-size:2em;margin-bottom:.5em}@media screen and (max-width:768px){.wcv-shop-header-name{font-size:1.5em}}

--- a/assets/css/wcv-store.scss
+++ b/assets/css/wcv-store.scss
@@ -1,0 +1,7 @@
+.wcv-shop-header-name {
+  font-size: 2em;
+  margin-bottom: 0.5em;
+  @media screen and (max-width: 768px) {
+    font-size: 1.5em;
+  }
+}

--- a/classes/front/dashboard/class-vendor-dashboard.php
+++ b/classes/front/dashboard/class-vendor-dashboard.php
@@ -46,6 +46,8 @@ class WCV_Vendor_Dashboard {
 		) {
 			wp_enqueue_style( 'wcv_frontend_style', wcv_assets_url . 'css/wcv-frontend.css' );			
 		}
+
+		wp_enqueue_style( 'wcv_vendor_store_style', wcv_assets_url . 'css/wcv-store.css' );
 	}
 
 	public function save_vendor_settings() {

--- a/templates/front/vendor-main-header.php
+++ b/templates/front/vendor-main-header.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<h1><?php echo $shop_name; ?></h1>
+<div class="wcv-shop-header-name"><?php echo $shop_name; ?></div>
 <div class="wcv_shop_description">
 	<?php echo $shop_description; ?>
 </div>

--- a/templates/front/vendor-mini-header.php
+++ b/templates/front/vendor-mini-header.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<h1><?php echo $shop_name; ?></h1>
+<div class="wcv-shop-header-name"><?php echo $shop_name; ?></div>
 <div class="wcv_shop_description">
 	<?php echo $shop_description; ?>
 </div>


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #839.
- Change H1 tag to div
- Added: wcv-store.css/scss

### How to test the changes in this Pull Request:

1. Go to the product page or vendor store page
2. Check h1 tag on the Vendor shop name is gone and has been changed to div

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
