### PR TITLE
Prepare v2.4.2 for release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 Changelog for WC Vendors Marketplace
 
+Version 2.4.2 - 16th May 2022
+
+* Updated: Dev tools (#842)
+* Fixed: Vendor menu shows on Admin dashboard (#844)
+* Fixed: Duplicate H1 tag on products (#840)
+* Fixed: The colspan does not match in vendor dashboard (#838)
+
 Version 2.4.1 - 3rd March 2022
 
 * Updated: Sales report with refund details (#822)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Changelog for WC Vendors Marketplace
 
-Version 2.4.2 - 16th May 2022
+Version 2.4.2 - 19th May 2022
 
 * Updated: Dev tools (#842)
 * Fixed: Vendor menu shows on Admin dashboard (#844)

--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -7,11 +7,11 @@
  * Author URI:           https://www.wcvendors.com
  * GitHub Plugin URI:    https://github.com/wcvendors/wcvendors
  *
- * Version:              2.4.1
+ * Version:              2.4.2
  * Requires at least:    5.3.0
  * Tested up to:         6.0
  * WC requires at least: 5.0
- * WC tested up to:      6.2.1
+ * WC tested up to:      6.5
  *
  * Text Domain:          wc-vendors
  * Domain Path:          /languages/
@@ -106,7 +106,7 @@ if ( wcv_is_woocommerce_activated() ) {
 	 */
 	class WC_Vendors {
 
-		public $version = '2.4.1';
+		public $version = '2.4.2';
 
 		/**
 		 * @var

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-vendors",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.3.3",

--- a/readme.txt
+++ b/readme.txt
@@ -264,7 +264,7 @@ WC Vendors Marketplace does not work with multisite WordPress. There are no plan
 
 == Changelog ==
 
-== Version 2.4.2 - 16th May 2022 ==
+== Version 2.4.2 - 19th May 2022 ==
 
 * Updated: Dev tools (#842)
 * Fixed: Vendor menu shows on Admin dashboard (#844)

--- a/readme.txt
+++ b/readme.txt
@@ -8,8 +8,8 @@ Requires at least: 5.3.0
 Requires PHP: 7.4
 Tested up to: 6.0
 WC requires at least: 5.0.0
-WC tested up to: 6.2.1
-Stable tag: 2.4.1
+WC tested up to: 6.5
+Stable tag: 2.4.2
 License: GPLv2 or later
 
 The original multi-vendor marketplace plugin for WordPress and WooCommerce. Best support available. 
@@ -263,6 +263,13 @@ WC Vendors Marketplace does not work with multisite WordPress. There are no plan
 12. Email notifications for admins, customers and vendors
 
 == Changelog ==
+
+== Version 2.4.2 - 16th May 2022 ==
+
+* Updated: Dev tools (#842)
+* Fixed: Vendor menu shows on Admin dashboard (#844)
+* Fixed: Duplicate H1 tag on products (#840)
+* Fixed: The colspan does not match in vendor dashboard (#838)
 
  = Version 2.4.1 - 3rd March 2022 =
 


### PR DESCRIPTION
## Prepare v2.4.2 for release
### Changelog:
Version 2.4.2 - 16th May 2022

* Updated: Dev tools (#842)
* Fixed: Vendor menu shows on Admin dashboard (#844)
* Fixed: Duplicate H1 tag on products (#840)
* Fixed: The colspan does not match in vendor dashboard (#838)