### PR TITLE
Fixed: New vendor list pagination doesn't work when using the display…

### DIFF
--- a/classes/includes/class-wcv-shortcodes.php
+++ b/classes/includes/class-wcv-shortcodes.php
@@ -646,9 +646,11 @@ class WCV_Shortcodes {
 	}
 
 	/**
-	 *    list of vendors
+	 * List of vendors
 	 *
-	 * @param $atts shortcode attributs
+	 * @param array $atts shortcode attributs.
+	 * @version 2.5 Fix pagination conflit with display mode
+	 * @return string
 	 */
 	public function wcv_vendorslist( $atts ) {
 
@@ -761,9 +763,10 @@ class WCV_Shortcodes {
 		if ( $total_vendors > $total_vendors_paged ) {
 			$html        .= '<div class="woocommerce-pagination">';
 			$current_page = max( 1, get_query_var( 'paged' ) );
+			$big          = 999999999; // need an unlikely integer.
 			$html        .= paginate_links(
 				array(
-					'base'      => get_pagenum_link() . '%_%',
+					'base'      => str_replace( $big, '%#%', esc_url( get_pagenum_link( $big ) ) ),
 					'format'    => 'page/%#%/',
 					'current'   => $current_page,
 					'total'     => $total_pages,


### PR DESCRIPTION
… options grid or list.

### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #869.

### How to test the changes in this Pull Request:

1. Go to the new vendor list page
2. Click on the list or grid.
3. Scroll down to try to go to page 2.
4. Pagination should work

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
