### PR TITLE
Fix new product notifications with duplicate execution

### DIFF
--- a/classes/admin/emails/class-wcv-admin-notify-product.php
+++ b/classes/admin/emails/class-wcv-admin-notify-product.php
@@ -37,8 +37,8 @@ if ( ! class_exists( 'WCVendors_Admin_Notify_Product' ) ) :
 			);
 
 			// Triggers for this email
-			add_action( 'pending_product', array( $this, 'trigger' ), 10, 2 );
-			add_action( 'pending_product_variation', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'draft_to_pending', array( $this, 'trigger' ), 10, 1 );
+			add_action( 'new_to_pending', array( $this, 'trigger' ), 10, 1 );
 
 			// Call parent constructor
 			parent::__construct();
@@ -75,14 +75,29 @@ if ( ! class_exists( 'WCVendors_Admin_Notify_Product' ) ) :
 		 * @param int      $order_id The order ID.
 		 * @param WC_Order $order    Order object.
 		 */
-		public function trigger( $post_id, $post ) {
+		public function trigger( $post ) {
 
 			$this->setup_locale();
+
+			$allow_postype = apply_filters( 'wcvendors_notify_allow_product_type', array( 'product', 'product_variation' ) );
+
+			if ( ! is_a( $post, 'WP_Post' ) ) {
+				return;
+			}
+
+			if ( $post->post_status !== 'pending' ) {
+				return;
+			}
+
+			if ( ! in_array( $post->post_type, $allow_postype ) ) {
+				return;
+			}
 
 			if ( ! WCV_Vendors::is_vendor( $post->post_author ) ) {
 				return;
 			}
 
+			$post_id           = $post->ID;
 			$this->post_id     = $post_id;
 			$this->vendor_id   = $post->post_author;
 			$this->product     = wc_get_product( $post_id );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix new product notification fire twice
Changed the `pending_product` hook to `draft_to_pending` and 'new_to_pending` hook

### How to test the changes in this Pull Request:

1. Adding new product via Pro Dashboard
2. Check the email by WP Mail Logging
3. See the email is sent only once

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
