### PR TITLE
Prepare for v2.4.4 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Changelog for WC Vendors Marketplace
 
-Version 2.4.4 - 28 December 2022
+Version 2.4.4 - 28 November 2022
 
 * Fixed: Admin notify product email firing twice
 * Fixed: New vendor list pagination doesn't work when using the display options grid or list. (#870)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 Changelog for WC Vendors Marketplace
 
+Version 2.4.4 - 28 December 2022
+
+* Fixed: Admin notify product email firing twice
+* Fixed: New vendor list pagination doesn't work when using the display options grid or list. (#870)
+
 Version 2.4.3 - 21 July 2022 
 
 * Added: Paypal Masspay Web CSV export (#860)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Changelog for WC Vendors Marketplace
 
-Version 2.4.4 - 28 November 2022
+Version 2.4.4 - 24 November 2022
 
 * Fixed: Admin notify product email firing twice
 * Fixed: New vendor list pagination doesn't work when using the display options grid or list. (#870)

--- a/class-wc-vendors.php
+++ b/class-wc-vendors.php
@@ -7,11 +7,11 @@
  * Author URI:           https://www.wcvendors.com
  * GitHub Plugin URI:    https://github.com/wcvendors/wcvendors
  *
- * Version:              2.4.3
+ * Version:              2.4.4
  * Requires at least:    5.3.0
- * Tested up to:         6.1.0
+ * Tested up to:         6.1.1
  * WC requires at least: 5.0
- * WC tested up to:      6.7
+ * WC tested up to:      7.1.0
  *
  * Text Domain:          wc-vendors
  * Domain Path:          /languages/
@@ -106,7 +106,7 @@ if ( wcv_is_woocommerce_activated() ) {
 	 */
 	class WC_Vendors {
 
-		public $version = '2.4.3';
+		public $version = '2.4.4';
 
 		/**
 		 * @var

--- a/classes/admin/emails/class-wcv-admin-notify-product.php
+++ b/classes/admin/emails/class-wcv-admin-notify-product.php
@@ -72,14 +72,13 @@ if ( ! class_exists( 'WCVendors_Admin_Notify_Product' ) ) :
 		/**
 		 * Trigger the sending of this email.
 		 *
-		 * @param int      $order_id The order ID.
-		 * @param WC_Order $order    Order object.
+		 * @param WP_Post $post The post object.
 		 */
 		public function trigger( $post ) {
 
 			$this->setup_locale();
 
-			$allow_postype = apply_filters( 'wcvendors_notify_allow_product_type', array( 'product', 'product_variation' ) );
+			$allow_posttype = apply_filters( 'wcvendors_notify_allow_product_type', array( 'product', 'product_variation' ) );
 
 			if ( ! is_a( $post, 'WP_Post' ) ) {
 				return;
@@ -89,7 +88,7 @@ if ( ! class_exists( 'WCVendors_Admin_Notify_Product' ) ) :
 				return;
 			}
 
-			if ( ! in_array( $post->post_type, $allow_postype ) ) {
+			if ( ! in_array( $post->post_type, $allow_posttype ) ) {
 				return;
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-vendors",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.3.3",

--- a/readme.txt
+++ b/readme.txt
@@ -275,6 +275,23 @@ WC Vendors Marketplace does not work with multisite WordPress. There are no plan
 * Fixed: Order status not getting updated with partial refund (#829)
 * Fixed: Shipping issue with WC Vendors Pro #1661 (#855)
 
+
+== Version 2.4.4 - 28 November 2022 ==
+
+* Fixed: Admin notify product email firing twice
+* Fixed: New vendor list pagination doesn't work when using the display options grid or list. (#870)
+
+== Version 2.4.3 - 21 July 2022 ==
+
+* Added: Paypal Masspay Web CSV export (#860)
+* Added: Vendor ID and Product Count Columns on user screen (#858)
+* Updated: Vendors list page redesign (#846)
+* Updated: Dutch translations thanks Eric (#865)
+* Updated: Show the Vendor selectbox while using Gutenberg for products (#853)
+* Fixed: Order Notification for the vendor does not include the coupon discount (#849)
+* Fixed: Order status not getting updated with partial refund (#829)
+* Fixed: Shipping issue with WC Vendors Pro #1661 (#855)
+
 == Version 2.4.2 - 19th May 2022 ==
 
 * Updated: Dev tools (#842)

--- a/readme.txt
+++ b/readme.txt
@@ -6,10 +6,10 @@ Author URI: https://www.wcvendors.com/
 Plugin URI: https://www.wcvendors.com/
 Requires at least: 5.3.0
 Requires PHP: 7.4
-Tested up to: 6.1
+Tested up to: 6.1.1
 WC requires at least: 5.0.0
-WC tested up to: 6.7
-Stable tag: 2.4.3
+WC tested up to: 7.1.0
+Stable tag: 2.4.4
 License: GPLv2 or later
 
 The original multi-vendor marketplace plugin for WordPress and WooCommerce. Best support available. 

--- a/readme.txt
+++ b/readme.txt
@@ -276,7 +276,7 @@ WC Vendors Marketplace does not work with multisite WordPress. There are no plan
 * Fixed: Shipping issue with WC Vendors Pro #1661 (#855)
 
 
-== Version 2.4.4 - 28 November 2022 ==
+== Version 2.4.4 - 24 November 2022 ==
 
 * Fixed: Admin notify product email firing twice
 * Fixed: New vendor list pagination doesn't work when using the display options grid or list. (#870)


### PR DESCRIPTION
- Prepare for the v2.4.4 release
- Fixed typo

### Changelog:
**Version 2.4.4 - 24 November 2022**

* Fixed: Admin notify product email firing twice
* Fixed: New vendor list pagination doesn't work when using the display options grid or list. (#870)