### PR TITLE
Fixed: Vendor select box incorrect or empty

### DIFF
--- a/assets/js/wcv-admin-quick-edit.js
+++ b/assets/js/wcv-admin-quick-edit.js
@@ -18,7 +18,7 @@ jQuery(function(){
         var wcv_inline_data = jQuery('#vendor_' + post_id),
             wc_inline_data = jQuery('#woocommerce_inline_' + post_id );
 
-        var vendor = wcv_inline_data.find("#_vendor").text();
+        var vendor = wcv_inline_data.find("#post_author").text();
 
         jQuery('select[name="post_author"] option[value="' + vendor + '"]', '.inline-edit-row').attr('selected', 'selected');
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Global $post variable return only one post, then the author is only author of the first post. So I use $wp_query to get authors on the list.
- Format code follow WPCS

### How to test the changes in this Pull Request:

1. Go to WP Dashboard → Products
2. Try to quick edit any product and see the vendor is selected correct vendor and not empty
3. Save and check the vendor is correct in both side : the list and in single product edit screen

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
